### PR TITLE
Implemented real use of player state, replaced stubs with real functionality.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <spring-cloud.version>2022.0.4</spring-cloud.version>
         <suite.security.version>0.0.1-SNAPSHOT</suite.security.version>
         <suite.reactive.version>1.0.5</suite.reactive.version>
+        <javafaker.version>1.0.2</javafaker.version>
     </properties>
 
     <dependencies>
@@ -74,6 +75,12 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-contract-stub-runner</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.javafaker</groupId>
+            <artifactId>javafaker</artifactId>
+            <version>${javafaker.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/odeyalo/sonata/connect/SonataConnectApplication.java
+++ b/src/main/java/com/odeyalo/sonata/connect/SonataConnectApplication.java
@@ -2,6 +2,7 @@ package com.odeyalo.sonata.connect;
 
 import com.odeyalo.sonata.connect.entity.InMemoryDevice;
 import com.odeyalo.sonata.connect.entity.InMemoryDevices;
+import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
 import com.odeyalo.sonata.connect.entity.PlayerState;
 import com.odeyalo.sonata.connect.model.DeviceType;
 import com.odeyalo.sonata.connect.model.PlayingType;
@@ -40,6 +41,7 @@ public class SonataConnectApplication {
                     .playing(true)
                     .playingType(PlayingType.TRACK)
                     .repeatState(RepeatState.OFF)
+                    .user(InMemoryUserEntity.builder().id("mikku").build())
                     .devices(devices)
                     .build();
             playerStateStorage.save(playerState).block();

--- a/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryDevice.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryDevice.java
@@ -1,6 +1,5 @@
 package com.odeyalo.sonata.connect.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.odeyalo.sonata.connect.model.DeviceType;
 import lombok.*;
 import lombok.experimental.FieldDefaults;

--- a/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryPlayerState.java
@@ -1,12 +1,9 @@
 package com.odeyalo.sonata.connect.entity;
 
-import com.odeyalo.sonata.connect.model.DeviceType;
 import com.odeyalo.sonata.connect.model.PlayingType;
 import com.odeyalo.sonata.connect.model.RepeatState;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
-
-import java.util.List;
 
 @Builder
 @Data
@@ -21,6 +18,8 @@ public class InMemoryPlayerState implements PlayerState {
     Long progressMs;
     PlayingType playingType;
     Devices devices;
+    UserEntity user;
+
     @Override
     public boolean getShuffleState() {
         return shuffleState;

--- a/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryUserEntity.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryUserEntity.java
@@ -1,0 +1,13 @@
+package com.odeyalo.sonata.connect.entity;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class InMemoryUserEntity implements UserEntity {
+    String id;
+}

--- a/src/main/java/com/odeyalo/sonata/connect/entity/PlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/PlayerState.java
@@ -20,4 +20,6 @@ public interface PlayerState {
     boolean isPlaying();
 
     Devices getDevices();
+
+    UserEntity getUser();
 }

--- a/src/main/java/com/odeyalo/sonata/connect/entity/UserEntity.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/UserEntity.java
@@ -1,0 +1,10 @@
+package com.odeyalo.sonata.connect.entity;
+
+/**
+ * Represent the User entity
+ */
+public interface UserEntity {
+
+    String getId();
+
+}

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -1,0 +1,22 @@
+package com.odeyalo.sonata.connect.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor(staticName = "of")
+@Builder
+public class CurrentPlayerState {
+    Long id;
+    boolean playing;
+    RepeatState repeatState;
+    boolean shuffleState;
+    Long progressMs;
+    PlayingType playingType;
+    DevicesModel devices;
+
+    public boolean getShuffleState() {
+        return shuffleState;
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/model/DeviceModel.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/DeviceModel.java
@@ -1,0 +1,16 @@
+package com.odeyalo.sonata.connect.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@AllArgsConstructor(staticName = "of")
+@Builder
+public class DeviceModel {
+    String deviceId;
+    String deviceName;
+    DeviceType deviceType;
+    int volume;
+    boolean active;
+}

--- a/src/main/java/com/odeyalo/sonata/connect/model/DevicesModel.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/DevicesModel.java
@@ -1,0 +1,35 @@
+package com.odeyalo.sonata.connect.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+@Value
+@AllArgsConstructor(staticName = "of")
+@Builder
+public class DevicesModel {
+    List<DeviceModel> devices;
+
+    public boolean isEmpty() {
+        return devices.isEmpty();
+    }
+
+    public int size() {
+        return devices.size();
+    }
+
+    public DeviceModel get(int index) {
+        return devices.get(index);
+    }
+
+    public void addDevice(DeviceModel device) {
+        this.devices.add(device);
+    }
+
+    public Stream<DeviceModel> stream() {
+        return devices.stream();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/model/User.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/User.java
@@ -1,0 +1,16 @@
+package com.odeyalo.sonata.connect.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ *  Model that represent User
+ */
+@AllArgsConstructor(staticName = "of")
+@Builder
+@Value
+public class User {
+    String id;
+}
+

--- a/src/main/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepository.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepository.java
@@ -11,13 +11,17 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class InMemoryPlayerStateRepository implements PlayerStateRepository<InMemoryPlayerState> {
     private final Map<Long, InMemoryPlayerState> cache = new ConcurrentHashMap<>();
+    private final Map<String, Long> cacheByUserId = new ConcurrentHashMap<>();
 
     @Override
     public Mono<InMemoryPlayerState> save(InMemoryPlayerState entity) {
         if (entity.getId() == null || entity.getId() <= 0) {
             return Mono.error(new IllegalArgumentException("The id is invalid"));
         }
-        return Mono.justOrEmpty(cache.put(entity.getId(), entity))
+        return Mono.fromRunnable(() -> {
+                    cache.put(entity.getId(), entity);
+                    cacheByUserId.put(entity.getUser().getId(), entity.getId());
+                })
                 .thenReturn(entity);
     }
 
@@ -41,5 +45,11 @@ public class InMemoryPlayerStateRepository implements PlayerStateRepository<InMe
     @Override
     public RepositoryType getRepositoryType() {
         return RepositoryType.IN_MEMORY;
+    }
+
+    @Override
+    public Mono<InMemoryPlayerState> findByUserId(String userId) {
+        return Mono.justOrEmpty(cacheByUserId.get(userId))
+                .map(cache::get);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/repository/PlayerStatePersistentOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/PlayerStatePersistentOperations.java
@@ -1,6 +1,13 @@
 package com.odeyalo.sonata.connect.repository;
 
 import com.odeyalo.sonata.connect.entity.PlayerState;
+import reactor.core.publisher.Mono;
 
 public interface PlayerStatePersistentOperations<T extends PlayerState> extends BasicPersistentOperations<T, Long> {
+    /**
+     * Search for the PlayerState associated with given user
+     * @param userId - user id to use
+     * @return - mono with user or empty
+     */
+    Mono<T> findByUserId(String userId);
 }

--- a/src/main/java/com/odeyalo/sonata/connect/repository/storage/PersistablePlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/storage/PersistablePlayerState.java
@@ -2,6 +2,7 @@ package com.odeyalo.sonata.connect.repository.storage;
 
 import com.odeyalo.sonata.connect.entity.Devices;
 import com.odeyalo.sonata.connect.entity.PlayerState;
+import com.odeyalo.sonata.connect.entity.UserEntity;
 import com.odeyalo.sonata.connect.model.DeviceType;
 import com.odeyalo.sonata.connect.model.PlayingType;
 import com.odeyalo.sonata.connect.model.RepeatState;
@@ -24,6 +25,7 @@ public class PersistablePlayerState implements PlayerState {
     Long progressMs;
     PlayingType playingType;
     Devices devices;
+    UserEntity user;
 
     @Override
     public boolean getShuffleState() {

--- a/src/main/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorage.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorage.java
@@ -3,7 +3,6 @@ package com.odeyalo.sonata.connect.repository.storage;
 import com.odeyalo.sonata.connect.entity.PlayerState;
 import com.odeyalo.sonata.connect.repository.PlayerStateRepository;
 import com.odeyalo.sonata.connect.repository.storage.support.PersistableEntityConverter;
-import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 public class RepositoryDelegatePlayerStateStorage implements PlayerStateStorage {
@@ -42,5 +41,11 @@ public class RepositoryDelegatePlayerStateStorage implements PlayerStateStorage 
 
     private PersistablePlayerState toPersistableEntity(PlayerState type) {
         return converter.convertTo(type);
+    }
+
+    @Override
+    public Mono<PersistablePlayerState> findByUserId(String userId) {
+        return delegate.findByUserId(userId)
+                .map(converter::convertTo);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/repository/storage/support/InMemory2PersistablePlayerStateConverter.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/storage/support/InMemory2PersistablePlayerStateConverter.java
@@ -16,6 +16,7 @@ public class InMemory2PersistablePlayerStateConverter implements PersistableEnti
                 .shuffleState(type.getShuffleState())
                 .progressMs(type.getProgressMs())
                 .repeatState(type.getRepeatState())
+                .user(type.getUser())
                 .devices(type.getDevices())
                 .build();
     }
@@ -29,6 +30,7 @@ public class InMemory2PersistablePlayerStateConverter implements PersistableEnti
                 .shuffleState(type.getShuffleState())
                 .progressMs(type.getProgressMs())
                 .repeatState(type.getRepeatState())
+                .user(type.getUser())
                 .devices(type.getDevices())
                 .build();
     }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/BasicPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/BasicPlayerOperations.java
@@ -1,0 +1,46 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.User;
+import reactor.core.publisher.Mono;
+
+/**
+ * Base interface that provide basic methods for player, such current player state, state updating, etc.
+ * This interface is also responsible for notification the subscribers(websockets, long pooling, etc.) on any player state update
+ */
+public interface BasicPlayerOperations {
+    boolean SHUFFLE_ENABLED = true;
+    boolean SHUFFLE_DISABLED = false;
+
+    /**
+     * Return the current state for the user
+     *
+     * @param user - user that owns the player state
+     * @return - mono wrapped with player state, empty mono if user owns nothing
+     */
+    Mono<CurrentPlayerState> currentState(User user);
+
+    /**
+     * Change the shuffle mode to provided in params.
+     * If shuffle mode is already same as provided DO NOTHING.
+     *
+     * @param user        - user that requested the shuffle update and is owner of the state
+     * @param shuffleMode - mode to update shuffle state
+     * @return mono with updated player state
+     */
+    Mono<CurrentPlayerState> changeShuffle(User user, boolean shuffleMode);
+
+    /**
+     * Alias for  #changeShuffle(User, true) method call
+     */
+    default Mono<CurrentPlayerState> enableShuffle(User user) {
+        return changeShuffle(user, SHUFFLE_ENABLED);
+    }
+
+    /**
+     * Alias for  #changeShuffle(User, false) method call
+     */
+    default Mono<CurrentPlayerState> disableShuffle(User user) {
+        return changeShuffle(user, SHUFFLE_DISABLED);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultBasicPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultBasicPlayerOperations.java
@@ -1,0 +1,71 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.entity.Device;
+import com.odeyalo.sonata.connect.entity.Devices;
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.DeviceModel;
+import com.odeyalo.sonata.connect.model.DevicesModel;
+import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
+import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+public class DefaultBasicPlayerOperations implements BasicPlayerOperations {
+    final PlayerStateStorage playerStateStorage;
+
+    public DefaultBasicPlayerOperations(PlayerStateStorage playerStateStorage) {
+        this.playerStateStorage = playerStateStorage;
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> currentState(User user) {
+        return playerStateStorage.findByUserId(user.getId())
+                .map(DefaultBasicPlayerOperations::convertToState);
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> changeShuffle(User user, boolean shuffleMode) {
+        return playerStateStorage.findByUserId(user.getId())
+                .map(state -> negateShuffleMode(state, shuffleMode))
+                .flatMap(playerStateStorage::save)
+                .map(DefaultBasicPlayerOperations::convertToState);
+    }
+
+    @NotNull
+    private static PersistablePlayerState negateShuffleMode(PersistablePlayerState state, boolean shuffleMode) {
+        state.setShuffleState(shuffleMode);
+        return state;
+    }
+
+    private static CurrentPlayerState convertToState(PersistablePlayerState state) {
+        return CurrentPlayerState.builder()
+                .id(state.getId())
+                .playingType(state.getPlayingType())
+                .playing(state.isPlaying())
+                .shuffleState(state.getShuffleState())
+                .progressMs(state.getProgressMs())
+                .repeatState(state.getRepeatState())
+                .devices(toDevicesDto(state.getDevices()))
+                .build();
+    }
+
+    private static DevicesModel toDevicesDto(Devices devices) {
+        List<DeviceModel> deviceModels = devices.stream().map(DefaultBasicPlayerOperations::toDeviceDto).toList();
+        return DevicesModel.builder().devices(deviceModels).build();
+    }
+
+    private static DeviceModel toDeviceDto(Device device) {
+        return DeviceModel.builder()
+                .deviceId(device.getId())
+                .deviceName(device.getName())
+                .deviceType(device.getDeviceType())
+                .volume(device.getVolume())
+                .active(device.isActive())
+                .build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultBasicPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultBasicPlayerOperations.java
@@ -50,16 +50,16 @@ public class DefaultBasicPlayerOperations implements BasicPlayerOperations {
                 .shuffleState(state.getShuffleState())
                 .progressMs(state.getProgressMs())
                 .repeatState(state.getRepeatState())
-                .devices(toDevicesDto(state.getDevices()))
+                .devices(toDevicesModel(state.getDevices()))
                 .build();
     }
 
-    private static DevicesModel toDevicesDto(Devices devices) {
-        List<DeviceModel> deviceModels = devices.stream().map(DefaultBasicPlayerOperations::toDeviceDto).toList();
+    private static DevicesModel toDevicesModel(Devices devices) {
+        List<DeviceModel> deviceModels = devices.stream().map(DefaultBasicPlayerOperations::toDeviceModel).toList();
         return DevicesModel.builder().devices(deviceModels).build();
     }
 
-    private static DeviceModel toDeviceDto(Device device) {
+    private static DeviceModel toDeviceModel(Device device) {
         return DeviceModel.builder()
                 .deviceId(device.getId())
                 .deviceName(device.getName())

--- a/src/test/java/com/odeyalo/sonata/connect/controller/CurrentPlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/CurrentPlayerStatePlayerControllerTest.java
@@ -2,9 +2,7 @@ package com.odeyalo.sonata.connect.controller;
 
 import com.odeyalo.sonata.connect.dto.ExceptionMessage;
 import com.odeyalo.sonata.connect.dto.PlayerStateDto;
-import com.odeyalo.sonata.connect.entity.InMemoryDevice;
-import com.odeyalo.sonata.connect.entity.InMemoryDevices;
-import com.odeyalo.sonata.connect.entity.PlayerState;
+import com.odeyalo.sonata.connect.entity.*;
 import com.odeyalo.sonata.connect.model.DeviceType;
 import com.odeyalo.sonata.connect.model.PlayingType;
 import com.odeyalo.sonata.connect.model.RepeatState;
@@ -35,7 +33,7 @@ import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerPro
         repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
         ids = "com.odeyalo.sonata:authorization:+")
 @TestPropertySource(locations = "classpath:application-test.properties")
-class PlayerControllerTest {
+class CurrentPlayerStatePlayerControllerTest {
 
     @Autowired
     WebTestClient webTestClient;
@@ -52,6 +50,7 @@ class PlayerControllerTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class ValidPlayerStateTests {
         final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+        final String VALID_USER_ID = "1";
 
         @BeforeAll
         void prepareData() {
@@ -72,6 +71,7 @@ class PlayerControllerTest {
                     .playingType(PlayingType.TRACK)
                     .repeatState(RepeatState.OFF)
                     .devices(devices)
+                    .user(InMemoryUserEntity.builder().id(VALID_USER_ID).build())
                     .build();
             playerStateStorage.save(playerState).block();
         }
@@ -217,7 +217,6 @@ class PlayerControllerTest {
     }
 
     @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     class UnauthorizedRequestTests {
         final String INVALID_ACCESS_TOKEN = "Bearer invalidtoken";
 

--- a/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
@@ -5,11 +5,7 @@ import com.odeyalo.sonata.connect.dto.ExceptionMessage;
 import com.odeyalo.sonata.connect.dto.PlayerStateDto;
 import com.odeyalo.sonata.connect.entity.InMemoryDevice;
 import com.odeyalo.sonata.connect.entity.InMemoryDevices;
-import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
-import com.odeyalo.sonata.connect.entity.PlayerState;
 import com.odeyalo.sonata.connect.model.DeviceType;
-import com.odeyalo.sonata.connect.model.PlayingType;
-import com.odeyalo.sonata.connect.model.RepeatState;
 import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
 import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
 import org.jetbrains.annotations.NotNull;
@@ -26,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Hooks;
+import testing.faker.PlayerStateFaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
@@ -116,16 +113,9 @@ public class UpdatePlayerStatePlayerControllerTest {
                             .active(true)
                             .build())
                     .build();
-            PersistablePlayerState playerState = PersistablePlayerState.builder()
-                    .id(1L)
-                    .shuffleState(PlayerState.SHUFFLE_DISABLED)
-                    .progressMs(0L)
-                    .playing(true)
-                    .playingType(PlayingType.TRACK)
-                    .repeatState(RepeatState.OFF)
-                    .devices(devices)
-                    .user(InMemoryUserEntity.builder().id(VALID_USER_ID).build())
-                    .build();
+            PersistablePlayerState playerState = PlayerStateFaker.createWithCustomNumberOfDevices(1)
+                    .setDevices(devices)
+                    .asPersistablePlayerState();
             playerStateStorage.save(playerState).block();
         }
 

--- a/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
@@ -1,0 +1,193 @@
+package com.odeyalo.sonata.connect.controller;
+
+
+import com.odeyalo.sonata.connect.dto.ExceptionMessage;
+import com.odeyalo.sonata.connect.dto.PlayerStateDto;
+import com.odeyalo.sonata.connect.entity.InMemoryDevice;
+import com.odeyalo.sonata.connect.entity.InMemoryDevices;
+import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
+import com.odeyalo.sonata.connect.entity.PlayerState;
+import com.odeyalo.sonata.connect.model.DeviceType;
+import com.odeyalo.sonata.connect.model.PlayingType;
+import com.odeyalo.sonata.connect.model.RepeatState;
+import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
+import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Hooks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureWebTestClient
+@AutoConfigureStubRunner(stubsMode = REMOTE,
+        repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
+        ids = "com.odeyalo.sonata:authorization:+")
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class UpdatePlayerStatePlayerControllerTest {
+
+    @Autowired
+    WebTestClient testClient;
+
+    @Autowired
+    PlayerStateStorage playerStateStorage;
+
+    final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+    final String VALID_USER_ID = "1";
+
+    @BeforeAll
+    void prepare() {
+        Hooks.onOperatorDebug(); // DO NOT DELETE IT, VERY IMPORTANT LINE, WITHOUT IT FEIGN WITH WIREMOCK THROWS ILLEGAL STATE EXCEPTION, I DON'T FIND SOLUTION YET
+    }
+
+    @Nested
+    class UnauthorizedRequestTests {
+        final String INVALID_ACCESS_TOKEN = "Bearer invalidtoken";
+
+        @Test
+        void expect401() {
+            WebTestClient.ResponseSpec responseSpec = sendUnauthorizedRequest();
+
+            responseSpec.expectStatus().isUnauthorized();
+        }
+
+        @Test
+        void expectApplicationJson() {
+            WebTestClient.ResponseSpec responseSpec = sendUnauthorizedRequest();
+
+            responseSpec.expectHeader().contentType(MediaType.APPLICATION_JSON);
+        }
+
+        @Test
+        void expectNotNullBody() {
+            WebTestClient.ResponseSpec responseSpec = sendUnauthorizedRequest();
+
+            ExceptionMessage message = responseSpec.expectBody(ExceptionMessage.class).returnResult().getResponseBody();
+
+            assertThat(message)
+                    .as("Body must be not null")
+                    .isNotNull();
+        }
+
+        @Test
+        void expectMessageInBody() {
+            WebTestClient.ResponseSpec responseSpec = sendUnauthorizedRequest();
+
+            ExceptionMessage message = responseSpec.expectBody(ExceptionMessage.class).returnResult().getResponseBody();
+
+            assertThat(message.getDescription())
+                    .as("Body must contain message with description")
+                    .isEqualTo("Missing access token or token has been expired");
+        }
+
+        private WebTestClient.ResponseSpec sendUnauthorizedRequest() {
+            return testClient.get()
+                    .uri("/player/shuffle")
+                    .header(HttpHeaders.AUTHORIZATION, INVALID_ACCESS_TOKEN)
+                    .exchange();
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class ChangeShuffleModeTests {
+
+        @BeforeAll
+        void prepareData() {
+            InMemoryDevices devices = InMemoryDevices.builder()
+                    .device(InMemoryDevice.builder()
+                            .id("something")
+                            .name("Miku")
+                            .deviceType(DeviceType.COMPUTER)
+                            .volume(50)
+                            .active(true)
+                            .build())
+                    .build();
+            PersistablePlayerState playerState = PersistablePlayerState.builder()
+                    .id(1L)
+                    .shuffleState(PlayerState.SHUFFLE_DISABLED)
+                    .progressMs(0L)
+                    .playing(true)
+                    .playingType(PlayingType.TRACK)
+                    .repeatState(RepeatState.OFF)
+                    .devices(devices)
+                    .user(InMemoryUserEntity.builder().id(VALID_USER_ID).build())
+                    .build();
+            playerStateStorage.save(playerState).block();
+        }
+
+        @Test
+        void expect204Status() {
+            WebTestClient.ResponseSpec responseSpec = sendValidChangeShuffleMode(true);
+
+            responseSpec.expectStatus().isNoContent();
+        }
+
+        @Test
+        void expectStateToBeChanged() {
+            PlayerStateDto currentState = getCurrentState();
+
+            boolean negatedShuffleState = negateShuffleState(currentState);
+
+            WebTestClient.ResponseSpec responseSpec = sendValidChangeShuffleMode(negatedShuffleState);
+
+            PlayerStateDto updatedState = getCurrentState();
+
+            assertThat(currentState)
+                    .as("The state must be updated!")
+                    .isNotEqualTo(updatedState);
+
+            assertThat(updatedState.getShuffleState())
+                    .as("The state must be negated!")
+                    .isEqualTo(negatedShuffleState);
+
+        }
+
+        private boolean negateShuffleState(PlayerStateDto currentState) {
+            return !currentState.getShuffleState();
+        }
+
+        private PlayerStateDto getCurrentState() {
+            return testClient.get()
+                    .uri("/player/state")
+                    .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                    .exchange()
+                    .expectBody(PlayerStateDto.class)
+                    .returnResult()
+                    .getResponseBody();
+        }
+
+        @Test
+        void sendRequestWithoutParams_andExpect400() {
+            WebTestClient.ResponseSpec responseSpec = sendValidChangeShuffleMode(null);
+
+            responseSpec.expectStatus().isBadRequest();
+        }
+
+        @NotNull
+        private WebTestClient.ResponseSpec sendValidChangeShuffleMode(Boolean state) {
+            return testClient.put()
+                    .uri(builder -> {
+                        if (state != null) {
+                            builder.queryParam("state", state);
+                        }
+                        return builder.path("/player/shuffle").build();
+                    })
+                    .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                    .exchange();
+        }
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepositoryTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepositoryTest.java
@@ -1,13 +1,10 @@
 package com.odeyalo.sonata.connect.repository;
 
 import com.odeyalo.sonata.connect.entity.InMemoryPlayerState;
-import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
-import com.odeyalo.sonata.connect.entity.PlayerState;
-import com.odeyalo.sonata.connect.model.PlayingType;
-import com.odeyalo.sonata.connect.model.RepeatState;
 import org.junit.jupiter.api.Test;
 import testing.PlayerStatePersistentOperationsTestAdapter;
 import testing.TestEntityGenerator;
+import testing.faker.PlayerStateFaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,30 +22,19 @@ class InMemoryPlayerStateRepositoryTest extends PlayerStatePersistentOperationsT
         assertThat(repositoryType).isEqualTo(RepositoryType.IN_MEMORY);
     }
 
-    static class InMemoryPlayerStateTestEntityGenerator implements TestEntityGenerator<PlayerState> {
+    static class InMemoryPlayerStateTestEntityGenerator implements TestEntityGenerator<InMemoryPlayerState> {
 
         @Override
-        public PlayerState generateValidEntity() {
-            return InMemoryPlayerState.builder()
-                    .id(1L)
-                    .repeatState(RepeatState.OFF)
-                    .shuffleState(false)
-                    .playing(true)
-                    .playingType(PlayingType.TRACK)
-                    .user(InMemoryUserEntity.builder().id("mikuuu").build())
-                    .build();
+        public InMemoryPlayerState generateValidEntity() {
+            return PlayerStateFaker.create()
+                    .asInMemoryPlayerState();
         }
 
         @Override
-        public PlayerState generateInvalidEntity() {
-            return InMemoryPlayerState.builder()
-                    .id(-1L)
-                    .repeatState(RepeatState.OFF)
-                    .shuffleState(false)
-                    .playing(true)
-                    .playingType(PlayingType.TRACK)
-                    .user(InMemoryUserEntity.builder().id("mikuuu").build())
-                    .build();
+        public InMemoryPlayerState generateInvalidEntity() {
+            return PlayerStateFaker.create()
+                    .setId(-1L)
+                    .asInMemoryPlayerState();
         }
     }
 }

--- a/src/test/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepositoryTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepositoryTest.java
@@ -1,7 +1,10 @@
 package com.odeyalo.sonata.connect.repository;
 
 import com.odeyalo.sonata.connect.entity.InMemoryPlayerState;
+import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
 import com.odeyalo.sonata.connect.entity.PlayerState;
+import com.odeyalo.sonata.connect.model.PlayingType;
+import com.odeyalo.sonata.connect.model.RepeatState;
 import org.junit.jupiter.api.Test;
 import testing.PlayerStatePersistentOperationsTestAdapter;
 import testing.TestEntityGenerator;
@@ -28,6 +31,11 @@ class InMemoryPlayerStateRepositoryTest extends PlayerStatePersistentOperationsT
         public PlayerState generateValidEntity() {
             return InMemoryPlayerState.builder()
                     .id(1L)
+                    .repeatState(RepeatState.OFF)
+                    .shuffleState(false)
+                    .playing(true)
+                    .playingType(PlayingType.TRACK)
+                    .user(InMemoryUserEntity.builder().id("mikuuu").build())
                     .build();
         }
 
@@ -35,6 +43,11 @@ class InMemoryPlayerStateRepositoryTest extends PlayerStatePersistentOperationsT
         public PlayerState generateInvalidEntity() {
             return InMemoryPlayerState.builder()
                     .id(-1L)
+                    .repeatState(RepeatState.OFF)
+                    .shuffleState(false)
+                    .playing(true)
+                    .playingType(PlayingType.TRACK)
+                    .user(InMemoryUserEntity.builder().id("mikuuu").build())
                     .build();
         }
     }

--- a/src/test/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorageTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorageTest.java
@@ -1,12 +1,10 @@
 package com.odeyalo.sonata.connect.repository.storage;
 
-import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
-import com.odeyalo.sonata.connect.model.PlayingType;
-import com.odeyalo.sonata.connect.model.RepeatState;
 import com.odeyalo.sonata.connect.repository.InMemoryPlayerStateRepository;
 import com.odeyalo.sonata.connect.repository.storage.support.InMemory2PersistablePlayerStateConverter;
 import testing.PlayerStatePersistentOperationsTestAdapter;
 import testing.TestEntityGenerator;
+import testing.faker.PlayerStateFaker;
 
 class RepositoryDelegatePlayerStateStorageTest extends PlayerStatePersistentOperationsTestAdapter {
 
@@ -18,26 +16,15 @@ class RepositoryDelegatePlayerStateStorageTest extends PlayerStatePersistentOper
 
         @Override
         public PersistablePlayerState generateValidEntity() {
-            return PersistablePlayerState.builder()
-                    .id(1L)
-                    .repeatState(RepeatState.OFF)
-                    .shuffleState(false)
-                    .playing(true)
-                    .playingType(PlayingType.TRACK)
-                    .user(InMemoryUserEntity.builder().id("mikuuuu").build())
-                    .build();
+            return PlayerStateFaker.create()
+                    .asPersistablePlayerState();
         }
 
         @Override
         public PersistablePlayerState generateInvalidEntity() {
-            return PersistablePlayerState.builder()
-                    .id(-1L)
-                    .repeatState(RepeatState.OFF)
-                    .shuffleState(false)
-                    .playing(false)
-                    .playingType(PlayingType.TRACK)
-                    .user(InMemoryUserEntity.builder().id("mikuuuu").build())
-                    .build();
+            return PlayerStateFaker.create()
+                    .setId(-1L)
+                    .asPersistablePlayerState();
         }
     }
 }

--- a/src/test/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorageTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorageTest.java
@@ -1,5 +1,8 @@
 package com.odeyalo.sonata.connect.repository.storage;
 
+import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
+import com.odeyalo.sonata.connect.model.PlayingType;
+import com.odeyalo.sonata.connect.model.RepeatState;
 import com.odeyalo.sonata.connect.repository.InMemoryPlayerStateRepository;
 import com.odeyalo.sonata.connect.repository.storage.support.InMemory2PersistablePlayerStateConverter;
 import testing.PlayerStatePersistentOperationsTestAdapter;
@@ -17,6 +20,11 @@ class RepositoryDelegatePlayerStateStorageTest extends PlayerStatePersistentOper
         public PersistablePlayerState generateValidEntity() {
             return PersistablePlayerState.builder()
                     .id(1L)
+                    .repeatState(RepeatState.OFF)
+                    .shuffleState(false)
+                    .playing(true)
+                    .playingType(PlayingType.TRACK)
+                    .user(InMemoryUserEntity.builder().id("mikuuuu").build())
                     .build();
         }
 
@@ -24,6 +32,11 @@ class RepositoryDelegatePlayerStateStorageTest extends PlayerStatePersistentOper
         public PersistablePlayerState generateInvalidEntity() {
             return PersistablePlayerState.builder()
                     .id(-1L)
+                    .repeatState(RepeatState.OFF)
+                    .shuffleState(false)
+                    .playing(false)
+                    .playingType(PlayingType.TRACK)
+                    .user(InMemoryUserEntity.builder().id("mikuuuu").build())
                     .build();
         }
     }

--- a/src/test/java/testing/PlayerStatePersistentOperationsTestAdapter.java
+++ b/src/test/java/testing/PlayerStatePersistentOperationsTestAdapter.java
@@ -85,4 +85,14 @@ public class PlayerStatePersistentOperationsTestAdapter {
                 .as("The size should not be changed, if ID does not exist")
                 .isEqualTo(beforeDeletion);
     }
+
+    @Test
+    public void shouldFindByUserId() {
+        PlayerState result = this.testTarget.findByUserId(entity.getUser().getId()).block();
+
+        assertThat(result)
+                .as("Entity must be found by user id!")
+                .isNotNull()
+                .isEqualTo(entity);
+    }
 }

--- a/src/test/java/testing/faker/DeviceFaker.java
+++ b/src/test/java/testing/faker/DeviceFaker.java
@@ -1,0 +1,55 @@
+package testing.faker;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.javafaker.Faker;
+import com.odeyalo.sonata.connect.entity.Device;
+import com.odeyalo.sonata.connect.entity.InMemoryDevice;
+import com.odeyalo.sonata.connect.entity.InMemoryPlayerState;
+import com.odeyalo.sonata.connect.model.DeviceType;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import org.apache.commons.lang3.RandomStringUtils;
+
+@Setter
+@Accessors(chain = true)
+public class DeviceFaker {
+    String deviceId;
+    String deviceName;
+    DeviceType deviceType;
+    int volume;
+    boolean active;
+
+
+    final Faker faker = Faker.instance();
+
+    protected DeviceFaker() {
+        this.deviceId = RandomStringUtils.randomAlphanumeric(10);
+        this.deviceName = RandomStringUtils.randomAlphabetic(15);
+        this.deviceType = faker.options().option(DeviceType.class);
+        this.volume = faker.random().nextInt(0, 100);
+        this.active = faker.random().nextBoolean();
+    }
+
+    public static DeviceFaker create() {
+        return new DeviceFaker();
+    }
+
+    public Device get() {
+        return buildInMemoryDevice();
+    }
+
+    public Device asInMemoryDevice() {
+        return buildInMemoryDevice();
+    }
+
+    private InMemoryDevice buildInMemoryDevice() {
+        return InMemoryDevice
+                .builder()
+                .id(deviceId)
+                .name(deviceName)
+                .deviceType(deviceType)
+                .volume(volume)
+                .active(active)
+                .build();
+    }
+}

--- a/src/test/java/testing/faker/DevicesFaker.java
+++ b/src/test/java/testing/faker/DevicesFaker.java
@@ -1,0 +1,51 @@
+package testing.faker;
+
+import com.github.javafaker.Faker;
+import com.odeyalo.sonata.connect.entity.Device;
+import com.odeyalo.sonata.connect.entity.Devices;
+import com.odeyalo.sonata.connect.entity.InMemoryDevices;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DevicesFaker {
+    List<Device> devices = new ArrayList<>();
+
+    Faker faker = Faker.instance();
+
+    public DevicesFaker() {
+        int numberOfDevices = faker.random().nextInt(1, 7);
+        for (int i = 0; i < numberOfDevices; i++) {
+            Device device = DeviceFaker.create().get();
+            this.devices.add(device);
+        }
+    }
+
+    public DevicesFaker(int numberOfDevices) {
+        for (int i = 0; i < numberOfDevices; i++) {
+            Device device = DeviceFaker.create().get();
+            this.devices.add(device);
+        }
+    }
+
+    public static DevicesFaker create() {
+        return new DevicesFaker();
+    }
+    public static DevicesFaker create(int numberOfDevices) {
+        return new DevicesFaker(numberOfDevices);
+    }
+
+    public Devices get() {
+        return buildInMemoryDevices();
+    }
+
+    public InMemoryDevices asInMemoryDevices() {
+        return buildInMemoryDevices();
+    }
+
+    private InMemoryDevices buildInMemoryDevices() {
+        return InMemoryDevices.builder()
+                .devices(devices)
+                .build();
+    }
+}

--- a/src/test/java/testing/faker/PlayerStateFaker.java
+++ b/src/test/java/testing/faker/PlayerStateFaker.java
@@ -1,0 +1,92 @@
+package testing.faker;
+
+import com.github.javafaker.Faker;
+import com.odeyalo.sonata.connect.entity.Devices;
+import com.odeyalo.sonata.connect.entity.InMemoryPlayerState;
+import com.odeyalo.sonata.connect.entity.PlayerState;
+import com.odeyalo.sonata.connect.entity.UserEntity;
+import com.odeyalo.sonata.connect.model.PlayingType;
+import com.odeyalo.sonata.connect.model.RepeatState;
+import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
+import lombok.AccessLevel;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.experimental.FieldDefaults;
+
+@Setter
+@Accessors(chain = true)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class PlayerStateFaker {
+    Long id;
+    boolean playing;
+    RepeatState repeatState;
+    boolean shuffleState;
+    Long progressMs;
+    PlayingType playingType;
+    Devices devices;
+    UserEntity user;
+
+    final Faker faker = Faker.instance();
+
+    public PlayerStateFaker() {
+        this(-1);
+    }
+
+    public PlayerStateFaker(int numberOfDevices) {
+        initializeWithFakedValues(numberOfDevices);
+    }
+
+    private void initializeWithFakedValues(int numberOfDevices) {
+        this.id = Long.valueOf(faker.random().nextInt(0, 100000));
+        this.playing = faker.random().nextBoolean();
+        this.repeatState = faker.options().option(RepeatState.class);
+        this.shuffleState = faker.random().nextBoolean();
+        this.progressMs = faker.random().nextLong();
+        this.playingType = faker.options().option(PlayingType.class);
+        this.user = UserEntityFaker.create().get();
+
+        if (numberOfDevices <= 0) {
+            this.devices = DevicesFaker.create().get();
+        } else {
+            this.devices = DevicesFaker.create(numberOfDevices).get();
+        }
+    }
+
+    public static PlayerStateFaker create() {
+        return new PlayerStateFaker();
+    }
+
+    public static PlayerStateFaker createWithCustomNumberOfDevices(int deviceNumber) {
+        return new PlayerStateFaker(deviceNumber);
+    }
+
+    public PlayerState get() {
+        return asInMemoryPlayerState();
+    }
+
+    public PersistablePlayerState asPersistablePlayerState() {
+        return PersistablePlayerState.builder()
+                .id(id)
+                .repeatState(repeatState)
+                .shuffleState(shuffleState)
+                .devices(devices)
+                .playing(playing)
+                .playingType(playingType)
+                .progressMs(progressMs)
+                .user(user)
+                .build();
+    }
+
+    public InMemoryPlayerState asInMemoryPlayerState() {
+        return InMemoryPlayerState.builder()
+                .id(id)
+                .repeatState(repeatState)
+                .shuffleState(shuffleState)
+                .devices(devices)
+                .playing(playing)
+                .playingType(playingType)
+                .progressMs(progressMs)
+                .user(user)
+                .build();
+    }
+}

--- a/src/test/java/testing/faker/UserEntityFaker.java
+++ b/src/test/java/testing/faker/UserEntityFaker.java
@@ -1,0 +1,31 @@
+package testing.faker;
+
+import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
+import com.odeyalo.sonata.connect.entity.UserEntity;
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class UserEntityFaker {
+    String id;
+
+    public UserEntityFaker() {
+        this.id = RandomStringUtils.random(15);
+    }
+
+    public static UserEntityFaker create() {
+        return new UserEntityFaker();
+    }
+
+    public UserEntity get() {
+        return buildInMemoryUser();
+    }
+
+    public InMemoryUserEntity asInMemoryUser() {
+        return buildInMemoryUser();
+    }
+
+    private InMemoryUserEntity buildInMemoryUser() {
+        return InMemoryUserEntity.builder()
+                .id(id)
+                .build();
+    }
+}


### PR DESCRIPTION
Implemented real use of player state, replaced stubs with real functionality.
Written tests for new logic.
Added /player/shuffle endpoint. Written tests for it.
Added BasicPlayerOperatins that used to change the player state and notify the clients through different  ways such websockets, long pooling, etc. 
PLAYER NOTIFICATIONS ARE NOT IMPLEMENTED IN THIS PULL REQUEST.
