### PR TITLE
Http player state updates

### DIFF
--- a/src/main/java/com/odeyalo/sonata/connect/config/EmptyPlayerStateCreatorOnMissingWebFilter.java
+++ b/src/main/java/com/odeyalo/sonata/connect/config/EmptyPlayerStateCreatorOnMissingWebFilter.java
@@ -1,0 +1,34 @@
+package com.odeyalo.sonata.connect.config;
+
+import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.service.player.BasicPlayerOperations;
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+/**
+ * Web filter that used to create empty player state if it is missing for the user
+ */
+@Component
+public class EmptyPlayerStateCreatorOnMissingWebFilter implements WebFilter {
+
+    final BasicPlayerOperations playerOperations;
+
+    public EmptyPlayerStateCreatorOnMissingWebFilter(BasicPlayerOperations playerOperations) {
+        this.playerOperations = playerOperations;
+    }
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        return ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication)
+                .cast(AuthenticatedUser.class)
+                .map(user -> User.of(user.getDetails().getId()))
+                .flatMap(playerOperations::createState)
+                .flatMap(state -> chain.filter(exchange));
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/connect/config/security/SecurityConfiguration.java
@@ -31,9 +31,10 @@ public class SecurityConfiguration {
 
     @Bean
     public SecurityWebFilterChain defaultFilterChain(ServerHttpSecurity httpSecurity) {
-        return httpSecurity.authorizeExchange((spec) -> spec.anyExchange().authenticated())
-                .cors(ServerHttpSecurity.CorsSpec::disable)
-                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+        return httpSecurity.authorizeExchange(authorizeExchangeSpecCustomizer)
+                .cors(corsSpecCustomizer)
+                .csrf(csrfSpecCustomizer)
+                .exceptionHandling(exceptionHandlingSpecCustomizer)
                 .addFilterAt(authenticationManagerFilter, SecurityWebFiltersOrder.AUTHENTICATION)
                 .build();
     }

--- a/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
@@ -1,16 +1,14 @@
 package com.odeyalo.sonata.connect.controller;
 
-import com.odeyalo.sonata.connect.dto.DeviceDto;
-import com.odeyalo.sonata.connect.dto.DevicesDto;
-import com.odeyalo.sonata.connect.dto.PlayerStateDto;
-import com.odeyalo.sonata.connect.model.CurrentPlayerState;
-import com.odeyalo.sonata.connect.model.DeviceModel;
-import com.odeyalo.sonata.connect.model.DevicesModel;
-import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.dto.*;
+import com.odeyalo.sonata.connect.model.*;
 import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
 import com.odeyalo.sonata.connect.service.player.BasicPlayerOperations;
 import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
@@ -36,23 +34,56 @@ public class PlayerController {
                 .map(PlayerController::convertToPlayerStateDto);
     }
 
+    @GetMapping("/currently-playing")
+    public Mono<ResponseEntity<CurrentlyPlayingPlayerStateDto>> currentlyPlaying(AuthenticatedUser user) {
+        return playerOperations.currentlyPlayingState(User.of(user.getDetails().getId()))
+                .map(state -> ResponseEntity.ok( convertToDto(state)) )
+                .defaultIfEmpty(ResponseEntity.noContent().build());
+    }
+
+    private static CurrentlyPlayingPlayerStateDto convertToDto(CurrentlyPlayingPlayerState state) {
+        return CurrentlyPlayingPlayerStateDto.of(state.getShuffleState());
+    }
+
     @PutMapping("/shuffle")
-    public Mono<ResponseEntity<?>> changeShuffleState(AuthenticatedUser user, @RequestParam("state") boolean state) {
+    public Mono<ResponseEntity<?>> changeShuffleState(AuthenticatedUser user,
+                                                      @RequestParam("state") boolean state) {
 
         return playerOperations.changeShuffle(User.of(user.getDetails().getId()), state)
                 .subscribeOn(Schedulers.boundedElastic())
                 .map(playerState -> ResponseEntity.noContent().build());
     }
 
+
+
+    @PutMapping(value = "/device/connect", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<?>> addDevice(AuthenticatedUser authenticatedUser, @RequestBody ConnectDeviceRequest body) {
+        return playerOperations.getDeviceOperations().addDevice(User.of(authenticatedUser.getDetails().getId()), convertToDeviceModel(body))
+                .thenReturn(ResponseEntity.noContent()
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .build());
+    }
+
+    private static DeviceModel convertToDeviceModel(ConnectDeviceRequest body) {
+        return DeviceModel.of(body.getId(), body.getName(), body.getDeviceType(), body.getVolume(), true);
+    }
+
     private static PlayerStateDto convertToPlayerStateDto(CurrentPlayerState state) {
         return PlayerStateDto.builder()
-                .currentlyPlayingType(state.getPlayingType().name().toLowerCase())
+                .currentlyPlayingType(playingTypeOrNull(state))
                 .isPlaying(state.isPlaying())
                 .repeatState(state.getRepeatState())
                 .progressMs(state.getProgressMs())
                 .devices(toDevicesDto(state.getDevices()))
                 .shuffleState(state.getShuffleState())
                 .build();
+    }
+
+    private static String playingTypeOrNull(CurrentPlayerState state) {
+
+        PlayingType playingType = state.getPlayingType();
+
+        return playingType != null ? playingType.name().toLowerCase() : null;
     }
 
     private static DevicesDto toDevicesDto(DevicesModel devices) {

--- a/src/main/java/com/odeyalo/sonata/connect/dto/ConnectDeviceRequest.java
+++ b/src/main/java/com/odeyalo/sonata/connect/dto/ConnectDeviceRequest.java
@@ -1,0 +1,21 @@
+package com.odeyalo.sonata.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.odeyalo.sonata.connect.model.DeviceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Simple request body dto that used to connect device to the player
+ */
+@AllArgsConstructor(staticName = "of")
+@Builder
+@Data
+public class ConnectDeviceRequest {
+    String id;
+    String name;
+    @JsonProperty("device_type")
+    DeviceType deviceType;
+    byte volume;
+}

--- a/src/main/java/com/odeyalo/sonata/connect/dto/CurrentlyPlayingPlayerStateDto.java
+++ b/src/main/java/com/odeyalo/sonata/connect/dto/CurrentlyPlayingPlayerStateDto.java
@@ -1,0 +1,15 @@
+package com.odeyalo.sonata.connect.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Dto to return current playing state, if any
+ */
+@Data
+@AllArgsConstructor(staticName = "of")
+@NoArgsConstructor
+public class CurrentlyPlayingPlayerStateDto {
+    private Boolean shuffleState;
+}

--- a/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryDevices.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/InMemoryDevices.java
@@ -3,6 +3,7 @@ package com.odeyalo.sonata.connect.entity;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -13,6 +14,10 @@ import java.util.List;
 public class InMemoryDevices implements Devices {
     @Singular
     List<Device> devices;
+
+    public static InMemoryDevices empty() {
+        return new InMemoryDevices(new ArrayList<>());
+    }
 
     @Override
     public List<Device> getDevices() {

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentlyPlayingPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentlyPlayingPlayerState.java
@@ -1,0 +1,13 @@
+package com.odeyalo.sonata.connect.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+
+/**
+ * Immutable object to represent the currently playing object with player state
+ */
+@Value
+@AllArgsConstructor(staticName = "of")
+public class CurrentlyPlayingPlayerState {
+    Boolean shuffleState;
+}

--- a/src/main/java/com/odeyalo/sonata/connect/repository/BasicPersistentOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/BasicPersistentOperations.java
@@ -1,15 +1,44 @@
 package com.odeyalo.sonata.connect.repository;
 
-import com.odeyalo.sonata.connect.entity.PlayerState;
 import reactor.core.publisher.Mono;
 
+/**
+ * Represent basic operations that can be done for entity
+ * @param <T> - entity type
+ * @param <ID> - id of the enity
+ */
 public interface BasicPersistentOperations<T, ID> {
-
+    /**
+     * Save the given entity
+     * @param entity - entity to save
+     * @throws IllegalStateException if the entity has invalid signature, invalid value, etc
+     * @return mono with saved entity
+     */
     Mono<T> save(T entity);
 
+    /**
+     * Search for the entity by given id
+     * @param id - id associated with entity
+     * @return - found entity in mono, empty mono if nothing was found
+     */
     Mono<T> findById(ID id);
 
+    /**
+     * Delete the entity by id, do nothing if the entity with this id does not exist
+     * @param id - id associated with entity
+     * @return - empty mono in any case
+     */
     Mono<Void> deleteById(ID id);
 
+    /**
+     * Count all values in this storage
+     * @return - number of objects in this storage, never null or negative value
+     */
     Mono<Long> count();
+
+    /**
+     * Clear the given storage, useful for tests
+     * @return - clear the given storage, returns nothing.
+     */
+    Mono<Void> clear();
 }

--- a/src/main/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepository.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/InMemoryPlayerStateRepository.java
@@ -4,7 +4,6 @@ import com.odeyalo.sonata.connect.entity.InMemoryPlayerState;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -21,8 +20,7 @@ public class InMemoryPlayerStateRepository implements PlayerStateRepository<InMe
         return Mono.fromRunnable(() -> {
                     cache.put(entity.getId(), entity);
                     cacheByUserId.put(entity.getUser().getId(), entity.getId());
-                })
-                .thenReturn(entity);
+                }).thenReturn(entity);
     }
 
     @Override
@@ -40,6 +38,14 @@ public class InMemoryPlayerStateRepository implements PlayerStateRepository<InMe
     public Mono<Long> count() {
         return Mono.just(cache.size())
                 .map(Long::valueOf);
+    }
+
+    @Override
+    public Mono<Void> clear() {
+        return Mono.fromRunnable(() -> {
+            cache.clear();
+            cacheByUserId.clear();
+        });
     }
 
     @Override

--- a/src/main/java/com/odeyalo/sonata/connect/repository/PlayerStateRepository.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/PlayerStateRepository.java
@@ -1,9 +1,10 @@
 package com.odeyalo.sonata.connect.repository;
 
 import com.odeyalo.sonata.connect.entity.PlayerState;
-import org.springframework.data.repository.core.RepositoryMetadata;
 
 public interface PlayerStateRepository<T extends PlayerState> extends PlayerStatePersistentOperations<T> {
-
+    /**
+     * @return the repository type that this repo supports
+     */
     RepositoryType getRepositoryType();
 }

--- a/src/main/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorage.java
+++ b/src/main/java/com/odeyalo/sonata/connect/repository/storage/RepositoryDelegatePlayerStateStorage.java
@@ -32,6 +32,11 @@ public class RepositoryDelegatePlayerStateStorage implements PlayerStateStorage 
     }
 
     @Override
+    public Mono<Void> clear() {
+        return delegate.clear();
+    }
+
+    @Override
     public Mono<PersistablePlayerState> save(PersistablePlayerState playerState) {
         return Mono.just(playerState)
                 .map(state -> converter.convertFrom(playerState))

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/BasicPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/BasicPlayerOperations.java
@@ -1,12 +1,12 @@
 package com.odeyalo.sonata.connect.service.player;
 
 import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.CurrentlyPlayingPlayerState;
 import com.odeyalo.sonata.connect.model.User;
 import reactor.core.publisher.Mono;
 
 /**
  * Base interface that provide basic methods for player, such current player state, state updating, etc.
- * This interface is also responsible for notification the subscribers(websockets, long pooling, etc.) on any player state update
  */
 public interface BasicPlayerOperations {
     boolean SHUFFLE_ENABLED = true;
@@ -14,11 +14,29 @@ public interface BasicPlayerOperations {
 
     /**
      * Return the current state for the user
+     * The method should create new state for the user if current is not created yet.
      *
      * @param user - user that owns the player state
-     * @return - mono wrapped with player state, empty mono if user owns nothing
+     * @return - mono wrapped with player state, never returns empty mono.
      */
     Mono<CurrentPlayerState> currentState(User user);
+
+    /**
+     * Return the currently playing state, if nothing is playing right now empty mono should be returned.
+     * @param user - user to get the current player state
+     * @return - currently playing state or  empty mono
+     */
+    Mono<CurrentlyPlayingPlayerState> currentlyPlayingState(User user);
+
+    /**
+     * Create or return the player state for the user.
+     * Associate it with user and add ability to access it in the future
+     * @param user - user to create state to
+     * @return - mono with created player state or state that already present
+     */
+    default Mono<CurrentPlayerState> createState(User user) {
+        return currentState(user);
+    }
 
     /**
      * Change the shuffle mode to provided in params.
@@ -29,6 +47,8 @@ public interface BasicPlayerOperations {
      * @return mono with updated player state
      */
     Mono<CurrentPlayerState> changeShuffle(User user, boolean shuffleMode);
+
+    DeviceOperations getDeviceOperations();
 
     /**
      * Alias for  #changeShuffle(User, true) method call

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperations.java
@@ -1,0 +1,104 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.entity.*;
+import com.odeyalo.sonata.connect.model.*;
+import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
+import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Component
+public class DefaultPlayerOperations implements BasicPlayerOperations {
+    final PlayerStateStorage playerStateStorage;
+    final DeviceOperations deviceOperations;
+    final Logger logger = LoggerFactory.getLogger(DefaultPlayerOperations.class);
+
+    public DefaultPlayerOperations(PlayerStateStorage playerStateStorage, DeviceOperations deviceOperations) {
+        this.playerStateStorage = playerStateStorage;
+        this.deviceOperations = deviceOperations;
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> currentState(User user) {
+        return playerStateStorage.findByUserId(user.getId())
+                .switchIfEmpty(Mono.defer(() -> {
+                    PersistablePlayerState state = emptyState(user);
+                    logger.info("Created new empty player state due to missing for the user: {}", user);
+                    return playerStateStorage.save(state);
+                }))
+                .map(DefaultPlayerOperations::convertToState);
+    }
+
+    @Override
+    public Mono<CurrentlyPlayingPlayerState> currentlyPlayingState(User user) {
+        return currentState(user)
+                .filter(state -> state.isPlaying())
+                .map(state -> CurrentlyPlayingPlayerState.of(state.getShuffleState()));
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> changeShuffle(User user, boolean shuffleMode) {
+        return playerStateStorage.findByUserId(user.getId())
+                .map(state -> negateShuffleMode(state, shuffleMode))
+                .flatMap(playerStateStorage::save)
+                .map(DefaultPlayerOperations::convertToState);
+    }
+
+    @Override
+    public DeviceOperations getDeviceOperations() {
+        return deviceOperations;
+    }
+
+
+
+    private static PersistablePlayerState emptyState(User user) {
+        return PersistablePlayerState.builder()
+                .user(new InMemoryUserEntity(user.getId()))
+                .id(1L)
+                .repeatState(RepeatState.OFF)
+                .shuffleState(false)
+                .progressMs(-1L)
+                .playingType(null)
+                .playing(false)
+                .devices(InMemoryDevices.empty())
+                .build();
+    }
+
+    @NotNull
+    private static PersistablePlayerState negateShuffleMode(PersistablePlayerState state, boolean shuffleMode) {
+        state.setShuffleState(shuffleMode);
+        return state;
+    }
+
+    private static CurrentPlayerState convertToState(PersistablePlayerState state) {
+        return CurrentPlayerState.builder()
+                .id(state.getId())
+                .playingType(state.getPlayingType())
+                .playing(state.isPlaying())
+                .shuffleState(state.getShuffleState())
+                .progressMs(state.getProgressMs())
+                .repeatState(state.getRepeatState())
+                .devices(toDevicesModel(state.getDevices()))
+                .build();
+    }
+
+    private static DevicesModel toDevicesModel(Devices devices) {
+        List<DeviceModel> deviceModels = devices.stream().map(DefaultPlayerOperations::toDeviceModel).toList();
+        return DevicesModel.builder().devices(deviceModels).build();
+    }
+
+    private static DeviceModel toDeviceModel(Device device) {
+        return DeviceModel.builder()
+                .deviceId(device.getId())
+                .deviceName(device.getName())
+                .deviceType(device.getDeviceType())
+                .volume(device.getVolume())
+                .active(device.isActive())
+                .build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DeviceOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DeviceOperations.java
@@ -1,0 +1,21 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.DeviceModel;
+import com.odeyalo.sonata.connect.model.User;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Interface to handle basic operations for connected device
+ */
+public interface DeviceOperations {
+    
+    Mono<CurrentPlayerState> addDevice(User user, DeviceModel device);
+
+    Mono<Boolean> containsById(User user, String deviceId);
+
+    Mono<List<DeviceModel>> getConnectedDevices(User user);
+
+}

--- a/src/test/java/com/odeyalo/sonata/connect/controller/ConnectDevicePlayerStateControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/ConnectDevicePlayerStateControllerTest.java
@@ -1,0 +1,119 @@
+package com.odeyalo.sonata.connect.controller;
+
+import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
+import com.odeyalo.sonata.connect.dto.PlayerStateDto;
+import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Hooks;
+import testing.asserts.PlayerStateDtoAssert;
+import testing.faker.ConnectDeviceRequestFaker;
+
+import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureWebTestClient
+@AutoConfigureStubRunner(stubsMode = REMOTE,
+        repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
+        ids = "com.odeyalo.sonata:authorization:+")
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class ConnectDevicePlayerStateControllerTest {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Autowired
+    PlayerStateStorage playerStateStorage;
+
+    final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+    final String VALID_USER_ID = "1";
+
+    @BeforeAll
+    void setup() {
+        Hooks.onOperatorDebug(); // DO NOT DELETE IT, VERY IMPORTANT LINE, WITHOUT IT FEIGN WITH WIREMOCK THROWS ILLEGAL STATE EXCEPTION, I DON'T FIND SOLUTION YET
+    }
+
+    @AfterEach
+    void afterEach() {
+        playerStateStorage.clear().block();
+    }
+
+    @Test
+    void shouldReturnNoContentStatusCode() {
+        WebTestClient.ResponseSpec exchange = prepareValidAndSend();
+
+        exchange.expectStatus().isNoContent();
+    }
+
+    @Test
+    void shouldReturnApplicationJson() {
+        WebTestClient.ResponseSpec exchange = prepareValidAndSend();
+
+        exchange.expectHeader().contentType(MediaType.APPLICATION_JSON);
+    }
+
+    @Test
+    void deviceShouldBeAdded() {
+        ConnectDeviceRequest body = ConnectDeviceRequestFaker.create().get();
+
+        WebTestClient.ResponseSpec responseSpec = sendRequest(body);
+
+        PlayerStateDto afterRequest = getCurrentPlayerState();
+
+        PlayerStateDtoAssert.forState(afterRequest)
+                .devices().length(1);
+    }
+
+    @Test
+    void shouldUpdateStateWithValidDeviceInfo() {
+        ConnectDeviceRequest body = ConnectDeviceRequestFaker.create().get();
+
+        WebTestClient.ResponseSpec responseSpec = sendRequest(body);
+
+        PlayerStateDto afterRequest = getCurrentPlayerState();
+
+        PlayerStateDtoAssert.forState(afterRequest)
+                .devices().peekFirst()
+                .id(body.getId())
+                .name(body.getName())
+                .volume(body.getVolume())
+                .type(body.getDeviceType());
+    }
+
+    @NotNull
+    private WebTestClient.ResponseSpec prepareValidAndSend() {
+        ConnectDeviceRequest body = ConnectDeviceRequestFaker.create().get();
+        return sendRequest(body);
+    }
+
+    private PlayerStateDto getCurrentPlayerState() {
+        return webTestClient.get()
+                .uri("/player/state")
+                .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                .exchange().expectBody(PlayerStateDto.class)
+                .returnResult().getResponseBody();
+
+    }
+
+    @NotNull
+    private WebTestClient.ResponseSpec sendRequest(ConnectDeviceRequest connectDeviceRequest) {
+        return webTestClient.put()
+                .uri("/player/device/connect")
+                .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(connectDeviceRequest)
+                .exchange();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/controller/CurrentPlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/CurrentPlayerStatePlayerControllerTest.java
@@ -8,10 +8,7 @@ import com.odeyalo.sonata.connect.model.PlayingType;
 import com.odeyalo.sonata.connect.model.RepeatState;
 import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
 import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -267,5 +264,10 @@ class CurrentPlayerStatePlayerControllerTest {
                     .header(HttpHeaders.AUTHORIZATION, INVALID_ACCESS_TOKEN)
                     .exchange();
         }
+    }
+
+    @AfterAll
+    void afterAll() {
+        playerStateStorage.clear().block();
     }
 }

--- a/src/test/java/com/odeyalo/sonata/connect/controller/CurrentPlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/CurrentPlayerStatePlayerControllerTest.java
@@ -22,6 +22,9 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Hooks;
 import testing.asserts.PlayerStateDtoAssert;
+import testing.faker.DeviceFaker;
+import testing.faker.PlayerStateFaker;
+import testing.faker.UserEntityFaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
@@ -55,24 +58,26 @@ class CurrentPlayerStatePlayerControllerTest {
         @BeforeAll
         void prepareData() {
             InMemoryDevices devices = InMemoryDevices.builder()
-                    .device(InMemoryDevice.builder()
-                            .id("something")
-                            .name("Miku")
-                            .deviceType(DeviceType.COMPUTER)
-                            .volume(50)
-                            .active(true)
-                            .build())
+                    .device(DeviceFaker.create()
+                            .setDeviceId("something")
+                            .setDeviceName("Miku")
+                            .setDeviceType(DeviceType.COMPUTER)
+                            .setVolume(50)
+                            .setActive(true)
+                            .asInMemoryDevice())
                     .build();
-            PersistablePlayerState playerState = PersistablePlayerState.builder()
-                    .id(1L)
-                    .shuffleState(PlayerState.SHUFFLE_DISABLED)
-                    .progressMs(0L)
-                    .playing(true)
-                    .playingType(PlayingType.TRACK)
-                    .repeatState(RepeatState.OFF)
-                    .devices(devices)
-                    .user(InMemoryUserEntity.builder().id(VALID_USER_ID).build())
-                    .build();
+            UserEntity user = UserEntityFaker.create().setId(VALID_USER_ID).get();
+
+            PersistablePlayerState playerState = PlayerStateFaker.createWithCustomNumberOfDevices(1)
+                    .setId(1L)
+                    .setShuffleState(PlayerState.SHUFFLE_DISABLED)
+                    .setProgressMs(0L)
+                    .setPlaying(true)
+                    .setPlayingType(PlayingType.TRACK)
+                    .setRepeatState(RepeatState.OFF)
+                    .setDevices(devices)
+                    .setUser(user)
+                    .asPersistablePlayerState();
             playerStateStorage.save(playerState).block();
         }
 

--- a/src/test/java/com/odeyalo/sonata/connect/controller/CurrentlyPlayingPlayerStateControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/CurrentlyPlayingPlayerStateControllerTest.java
@@ -1,0 +1,142 @@
+package com.odeyalo.sonata.connect.controller;
+
+import com.odeyalo.sonata.connect.dto.CurrentlyPlayingPlayerStateDto;
+import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
+import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
+import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Hooks;
+import testing.asserts.CurrentlyPlayingPlayerStateDtoAssert;
+import testing.faker.PlayerStateFaker;
+
+import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureWebTestClient
+@AutoConfigureStubRunner(stubsMode = REMOTE,
+        repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
+        ids = "com.odeyalo.sonata:authorization:+")
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class CurrentlyPlayingPlayerStateControllerTest {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @Autowired
+    PlayerStateStorage playerStateStorage;
+
+    final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+    final String VALID_USER_ID = "1";
+    final String INVALID_ACCESS_TOKEN = "Bearer invalidtoken";
+
+    @BeforeAll
+    void setup() {
+        Hooks.onOperatorDebug(); // DO NOT DELETE IT, VERY IMPORTANT LINE, WITHOUT IT FEIGN WITH WIREMOCK THROWS ILLEGAL STATE EXCEPTION, I DON'T FIND SOLUTION YET
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CurrentlyPlayingForValidUser {
+        PersistablePlayerState expectedState;
+
+        @BeforeEach
+        void beforeEach() {
+            PersistablePlayerState playerState = createPlayingState();
+
+            expectedState = playerStateStorage.save(playerState).block();
+        }
+
+        @AfterEach
+        void afterEach() {
+            playerStateStorage.clear().block();
+        }
+
+        @Test
+        void shouldReturnCurrentlyPlayingState() {
+            CurrentlyPlayingPlayerStateDto body = sendAndGetBody();
+
+            CurrentlyPlayingPlayerStateDtoAssert.forBody(body)
+                    .shuffleState().isEqualTo(expectedState.getShuffleState());
+        }
+
+        private CurrentlyPlayingPlayerStateDto sendAndGetBody() {
+            WebTestClient.ResponseSpec responseSpec = sendRequest();
+            return responseSpec.expectBody(CurrentlyPlayingPlayerStateDto.class).returnResult().getResponseBody();
+        }
+
+        @Test
+        void shouldReturnApplicationJsonContentType() {
+            WebTestClient.ResponseSpec responseSpec = sendRequest();
+
+            responseSpec.expectHeader().contentType(MediaType.APPLICATION_JSON);
+        }
+
+        private PersistablePlayerState createPlayingState() {
+            return PlayerStateFaker.create()
+                    .setPlaying(true)
+                    .setUser(new InMemoryUserEntity(VALID_USER_ID))
+                    .asPersistablePlayerState();
+        }
+
+        public WebTestClient.ResponseSpec sendRequest() {
+            return webTestClient.get()
+                    .uri("/player/currently-playing")
+                    .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                    .exchange();
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CurrentlyPlayingForNothingPlayingWithValidRequestTests {
+
+        @Test
+        void shouldReturnNoContentStatus() {
+            WebTestClient.ResponseSpec responseSpec = sendRequest();
+
+            responseSpec.expectStatus().isNoContent();
+        }
+
+        public WebTestClient.ResponseSpec sendRequest() {
+            return webTestClient.get()
+                    .uri("/player/currently-playing")
+                    .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                    .exchange();
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    class CurrentlyPlayingForUnathorizedRequest {
+
+        @Test
+        void shouldReturn401Status() {
+            WebTestClient.ResponseSpec responseSpec = sendRequest();
+
+            responseSpec.expectStatus().isUnauthorized();
+        }
+
+        @Test
+        void shouldReturnApplicationJson() {
+            WebTestClient.ResponseSpec responseSpec = sendRequest();
+
+            responseSpec.expectHeader().contentType(MediaType.APPLICATION_JSON);
+        }
+
+        public WebTestClient.ResponseSpec sendRequest() {
+            return webTestClient.get()
+                    .uri("/player/currently-playing")
+                    .header(HttpHeaders.AUTHORIZATION, INVALID_ACCESS_TOKEN)
+                    .exchange();
+        }
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
@@ -9,10 +9,7 @@ import com.odeyalo.sonata.connect.model.DeviceType;
 import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
 import com.odeyalo.sonata.connect.repository.storage.PlayerStateStorage;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -181,5 +178,10 @@ public class UpdatePlayerStatePlayerControllerTest {
                     .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
                     .exchange();
         }
+    }
+
+    @AfterAll
+    void afterAll() {
+        playerStateStorage.clear().block();
     }
 }

--- a/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/UpdatePlayerStatePlayerControllerTest.java
@@ -22,6 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Hooks;
+import testing.faker.DeviceFaker;
+import testing.faker.DevicesFaker;
 import testing.faker.PlayerStateFaker;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -105,13 +107,13 @@ public class UpdatePlayerStatePlayerControllerTest {
         @BeforeAll
         void prepareData() {
             InMemoryDevices devices = InMemoryDevices.builder()
-                    .device(InMemoryDevice.builder()
-                            .id("something")
-                            .name("Miku")
-                            .deviceType(DeviceType.COMPUTER)
-                            .volume(50)
-                            .active(true)
-                            .build())
+                    .device(DeviceFaker.create()
+                            .setDeviceId("something")
+                            .setDeviceName("Miku")
+                            .setDeviceType(DeviceType.COMPUTER)
+                            .setVolume(50)
+                            .setActive(true)
+                            .asInMemoryDevice())
                     .build();
             PersistablePlayerState playerState = PlayerStateFaker.createWithCustomNumberOfDevices(1)
                     .setDevices(devices)

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperationsTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperationsTest.java
@@ -1,0 +1,129 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.DeviceModel;
+import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.repository.InMemoryPlayerStateRepository;
+import com.odeyalo.sonata.connect.repository.storage.PersistablePlayerState;
+import com.odeyalo.sonata.connect.repository.storage.RepositoryDelegatePlayerStateStorage;
+import com.odeyalo.sonata.connect.repository.storage.support.InMemory2PersistablePlayerStateConverter;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import testing.faker.PlayerStateFaker;
+
+import java.util.List;
+
+import static com.odeyalo.sonata.connect.service.player.BasicPlayerOperations.SHUFFLE_DISABLED;
+import static com.odeyalo.sonata.connect.service.player.BasicPlayerOperations.SHUFFLE_ENABLED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultPlayerOperationsTest {
+
+    RepositoryDelegatePlayerStateStorage storage = new RepositoryDelegatePlayerStateStorage(new InMemoryPlayerStateRepository(), new InMemory2PersistablePlayerStateConverter());
+
+    DefaultPlayerOperations playerOperations = new DefaultPlayerOperations(
+            storage,
+            new NullDeviceOperations()
+    );
+
+
+    @Test
+    void getStateForUser_andExpectStateToBeCreated() {
+        User user = User.of("odeyalooo");
+
+        CurrentPlayerState playerState = playerOperations.currentState(user).block();
+
+        assertThat(playerState).isNotNull();
+    }
+
+    @Test
+    void shouldReturnExistedState() {
+        PersistablePlayerState expected = PlayerStateFaker.create().asPersistablePlayerState();
+
+        PersistablePlayerState playerState = saveState(expected);
+
+        CurrentPlayerState actual = getCurrentPlayerState(playerState);
+
+        assertThat(actual).isNotNull();
+
+        assertThat(expected.getId()).isEqualTo(actual.getId());
+        assertThat(expected.getProgressMs()).isEqualTo(actual.getProgressMs());
+
+    }
+
+    @Nullable
+    private CurrentPlayerState getCurrentPlayerState(PersistablePlayerState playerState) {
+        return playerOperations.currentState(User.of(playerState.getUser().getId())).block();
+    }
+
+    @Test
+    void changeShuffleToEnabled_andExpectShuffleToChange() {
+        PersistablePlayerState playerState = saveState(createDisabledState());
+
+        CurrentPlayerState updatedState = playerOperations.changeShuffle(createUser(playerState), SHUFFLE_ENABLED).block();
+
+        assertThat(updatedState.getShuffleState()).isEqualTo(SHUFFLE_ENABLED);
+    }
+
+    @Test
+    void changeShuffleToDisabled_andExpectShuffleToChange() {
+        PersistablePlayerState playerState = saveState(createEnabledState());
+
+        CurrentPlayerState updatedState = playerOperations.changeShuffle(createUser(playerState), SHUFFLE_DISABLED).block();
+
+        assertThat(updatedState.getShuffleState()).isEqualTo(SHUFFLE_DISABLED);
+    }
+
+    @Test
+    void shouldChangeNothingIfStateIsEqual() {
+        PersistablePlayerState state = PlayerStateFaker.create().asPersistablePlayerState();
+        PersistablePlayerState savedPlayerState = saveState(state);
+
+        CurrentPlayerState updatedState = playerOperations.changeShuffle(createUser(savedPlayerState), state.getShuffleState()).block();
+
+        assertThat(updatedState.getShuffleState()).isEqualTo(state.getShuffleState());
+    }
+
+    private static User createUser(PersistablePlayerState playerState) {
+        return User.of(playerState.getUser().getId());
+    }
+
+    private PersistablePlayerState createEnabledState() {
+        return PlayerStateFaker
+                .create()
+                .setShuffleState(SHUFFLE_ENABLED)
+                .asPersistablePlayerState();
+    }
+
+    @Nullable
+    private PersistablePlayerState saveState(PersistablePlayerState playerState) {
+        return storage.save(playerState).block();
+    }
+
+    private static PersistablePlayerState createDisabledState() {
+        return PlayerStateFaker
+                .create()
+                .setShuffleState(SHUFFLE_DISABLED)
+                .asPersistablePlayerState();
+    }
+
+    static class NullDeviceOperations implements DeviceOperations {
+
+
+        @Override
+        public Mono<CurrentPlayerState> addDevice(User user, DeviceModel device) {
+            return null;
+        }
+
+        @Override
+        public Mono<Boolean> containsById(User user, String deviceId) {
+            return null;
+        }
+
+        @Override
+        public Mono<List<DeviceModel>> getConnectedDevices(User user) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/testing/PlayerStatePersistentOperationsTestAdapter.java
+++ b/src/test/java/testing/PlayerStatePersistentOperationsTestAdapter.java
@@ -95,4 +95,13 @@ public class PlayerStatePersistentOperationsTestAdapter {
                 .isNotNull()
                 .isEqualTo(entity);
     }
+
+    @Test
+    void shouldClear() {
+        testTarget.clear().block();
+
+        Long afterClear = testTarget.count().block();
+
+        assertThat(afterClear).isEqualTo(0);
+    }
 }

--- a/src/test/java/testing/asserts/CurrentlyPlayingPlayerStateDtoAssert.java
+++ b/src/test/java/testing/asserts/CurrentlyPlayingPlayerStateDtoAssert.java
@@ -1,0 +1,20 @@
+package testing.asserts;
+
+import com.odeyalo.sonata.connect.dto.CurrentlyPlayingPlayerStateDto;
+import org.assertj.core.api.AbstractAssert;
+
+public class CurrentlyPlayingPlayerStateDtoAssert extends AbstractAssert<CurrentlyPlayingPlayerStateDtoAssert, CurrentlyPlayingPlayerStateDto> {
+
+    public CurrentlyPlayingPlayerStateDtoAssert(CurrentlyPlayingPlayerStateDto actual) {
+        super(actual, CurrentlyPlayingPlayerStateDtoAssert.class);
+    }
+
+    public static CurrentlyPlayingPlayerStateDtoAssert forBody(CurrentlyPlayingPlayerStateDto actual) {
+        return new CurrentlyPlayingPlayerStateDtoAssert(actual);
+    }
+
+
+    public ShuffleStateAsserts shuffleState() {
+        return new ShuffleStateAsserts(actual.getShuffleState());
+    }
+}

--- a/src/test/java/testing/asserts/CurrentlyPlayingTypeAsserts.java
+++ b/src/test/java/testing/asserts/CurrentlyPlayingTypeAsserts.java
@@ -1,0 +1,27 @@
+package testing.asserts;
+
+import org.assertj.core.api.AbstractAssert;
+
+public class CurrentlyPlayingTypeAsserts extends AbstractAssert<CurrentlyPlayingTypeAsserts, String> {
+    public static final String TRACK = "track";
+    public static final String PODCAST = "podcast";
+
+    CurrentlyPlayingTypeAsserts(String actual) {
+        super(actual, CurrentlyPlayingTypeAsserts.class);
+     }
+
+    public CurrentlyPlayingTypeAsserts track() {
+        return currentPlayingTypeAssert(TRACK);
+    }
+
+    public CurrentlyPlayingTypeAsserts podcast() {
+        return currentPlayingTypeAssert(PODCAST);
+    }
+
+    private CurrentlyPlayingTypeAsserts currentPlayingTypeAssert(String expected) {
+        if (!actual.equals(expected)) {
+            failWithActualExpectedAndMessage(actual, expected, "Expected the playing type to be:");
+        }
+        return this;
+    }
+}

--- a/src/test/java/testing/asserts/DeviceEntityAssert.java
+++ b/src/test/java/testing/asserts/DeviceEntityAssert.java
@@ -1,0 +1,62 @@
+package testing.asserts;
+
+import com.odeyalo.sonata.connect.entity.Device;
+import com.odeyalo.sonata.connect.model.DeviceType;
+import org.assertj.core.api.AbstractAssert;
+import org.springframework.util.Assert;
+
+import static org.apache.commons.lang.BooleanUtils.isFalse;
+
+public class DeviceEntityAssert extends AbstractAssert<DeviceEntityAssert, Device> {
+
+    public DeviceEntityAssert(Device actual) {
+        super(actual, DeviceEntityAssert.class);
+    }
+
+    public static DeviceEntityAssert forDevice(Device actual) {
+        Assert.notNull(actual, "Actual must be not null");
+        return new DeviceEntityAssert(actual);
+    }
+
+    public DeviceEntityAssert id(String expectedId) {
+        if (!expectedId.equals(actual.getId())) {
+            failWithActualExpectedAndMessage(actual.getId(), expectedId, "Expected devices ID to be equal");
+        }
+        return this;
+    }
+
+    public DeviceEntityAssert name(String expectedName) {
+        if (!expectedName.equals(actual.getName())) {
+            failWithActualExpectedAndMessage(actual.getName(), expectedName, "Expected device names to be equal");
+        }
+        return this;
+    }
+
+    public DeviceEntityAssert type(DeviceType expectedType) {
+        if (expectedType != actual.getDeviceType()) {
+            failWithActualExpectedAndMessage(actual.getDeviceType(), expectedType, "Expected device types to be equal");
+        }
+        return this;
+    }
+
+    public DeviceEntityAssert volume(int expectedVolume) {
+        if (expectedVolume != actual.getVolume()) {
+            failWithActualExpectedAndMessage(actual.getVolume(), expectedVolume, "Expected device volumes to be equal");
+        }
+        return this;
+    }
+
+    public DeviceEntityAssert active() {
+        if (isFalse(actual.isActive())) {
+            failWithMessage("Expected device to be in 'inactive' state!");
+        }
+        return this;
+    }
+
+    public DeviceEntityAssert inactive() {
+        if (actual.isActive()) {
+            failWithMessage("Expected device to be in 'active' state!");
+        }
+        return this;
+    }
+}

--- a/src/test/java/testing/asserts/DevicesEntityAssert.java
+++ b/src/test/java/testing/asserts/DevicesEntityAssert.java
@@ -1,0 +1,59 @@
+package testing.asserts;
+
+import com.odeyalo.sonata.connect.entity.Device;
+import com.odeyalo.sonata.connect.entity.Devices;
+import org.assertj.core.api.AbstractAssert;
+import org.springframework.util.Assert;
+
+public class DevicesEntityAssert extends AbstractAssert<DevicesEntityAssert, Devices> {
+
+    protected DevicesEntityAssert(Devices actual) {
+        super(actual, DevicesEntityAssert.class);
+    }
+
+    public static DevicesEntityAssert forDevices(Devices actual) {
+        Assert.notNull(actual, "The actual must be not null!");
+        return new DevicesEntityAssert(actual);
+    }
+
+    public DevicesEntityAssert length(int requiredLength) {
+        if (actual.size() != requiredLength) {
+            failWithActualExpectedAndMessage(actual.size(), requiredLength, "Expected length to be equal");
+        }
+        return this;
+    }
+
+    public DevicesEntityAssert empty() {
+        if (!actual.isEmpty()) {
+            failWithMessage("Devices must be empty!");
+        }
+        return this;
+    }
+
+    public DevicesEntityAssert notEmpty() {
+        if (actual.isEmpty()) {
+            failWithMessage("Devices must be not empty!");
+        }
+        return this;
+    }
+
+    public DeviceEntityAssert peekFirst() {
+        return peek(0);
+    }
+
+    public DeviceEntityAssert peekSecond() {
+        return peek(1);
+    }
+
+    public DeviceEntityAssert peekThird() {
+        return peek(2);
+    }
+
+    public DeviceEntityAssert peek(int index) {
+        if (actual.size() <= index) {
+            failWithMessage("The devices length is: %s, but the index was: %s", actual.size(), index);
+        }
+        Device actual = this.actual.getDevice(index);
+        return new DeviceEntityAssert(actual);
+    }
+}

--- a/src/test/java/testing/asserts/PlayerStateAssert.java
+++ b/src/test/java/testing/asserts/PlayerStateAssert.java
@@ -1,0 +1,119 @@
+package testing.asserts;
+
+import com.odeyalo.sonata.connect.entity.Devices;
+import com.odeyalo.sonata.connect.entity.PlayerState;
+import com.odeyalo.sonata.connect.model.RepeatState;
+import org.assertj.core.api.AbstractAssert;
+import org.springframework.util.Assert;
+
+import static org.apache.commons.lang.BooleanUtils.isFalse;
+
+public class PlayerStateAssert extends AbstractAssert<PlayerStateAssert, PlayerState> {
+
+    private PlayerStateAssert(PlayerState actual) {
+        super(actual, PlayerStateAssert.class);
+    }
+
+    public static PlayerStateAssert forState(PlayerState actual) {
+        Assert.notNull(actual, "Actual value must be not null!");
+        return new PlayerStateAssert(actual);
+    }
+
+    public PlayerStateAssert shouldPlay() {
+        if (isFalse(actual.isPlaying())) {
+            failWithActualExpectedAndMessage(false, true, "Expected player with playing status!");
+        }
+        return this;
+    }
+
+    public PlayerStateAssert shouldBeStopped() {
+        if (actual.isPlaying()) {
+            failWithActualExpectedAndMessage(true, false, "Expected player with paused status!");
+        }
+        return this;
+    }
+
+    public RepeatStateAssertWrapper repeatState() {
+        return new RepeatStateAssertWrapper(actual.getRepeatState(), this);
+    }
+
+    public ShuffleStateAssertsWrapper shuffleState() {
+        return new ShuffleStateAssertsWrapper(actual.getShuffleState(), this);
+    }
+
+    public CurrentlyPlayingTypeAssertsWrapper currentlyPlayingType() {
+        return new CurrentlyPlayingTypeAssertsWrapper(actual.getCurrentlyPlayingType().name(), this);
+    }
+
+    public PlayerStateAssert progressMs(long expectedMs) {
+        if (actual.getProgressMs() != expectedMs) {
+            failWithActualExpectedAndMessage(actual.getProgressMs(), expectedMs, "The progress in ms must be equalQ!");
+        }
+        return null;
+    }
+
+    public DevicesEntityAssertWrapper devices() {
+        return new DevicesEntityAssertWrapper(actual.getDevices(), this);
+    }
+
+    interface ParentAssertAware {
+        PlayerStateAssert and();
+    }
+
+    public static class RepeatStateAssertWrapper extends RepeatStateAssert implements ParentAssertAware {
+
+        private final PlayerStateAssert parent;
+
+        protected RepeatStateAssertWrapper(RepeatState actual, PlayerStateAssert parent) {
+            super(actual);
+            this.parent = parent;
+        }
+
+        @Override
+        public PlayerStateAssert and() {
+            return parent;
+        }
+    }
+
+    public static class DevicesEntityAssertWrapper extends DevicesEntityAssert implements ParentAssertAware {
+        private final PlayerStateAssert parent;
+
+        protected DevicesEntityAssertWrapper(Devices actual, PlayerStateAssert parent) {
+            super(actual);
+            this.parent = parent;
+        }
+
+        @Override
+        public PlayerStateAssert and() {
+            return parent;
+        }
+    }
+
+    public static class ShuffleStateAssertsWrapper extends ShuffleStateAsserts implements ParentAssertAware {
+        private final PlayerStateAssert parent;
+
+        public ShuffleStateAssertsWrapper(Boolean actual, PlayerStateAssert parent) {
+            super(actual);
+            this.parent = parent;
+        }
+
+        @Override
+        public PlayerStateAssert and() {
+            return parent;
+        }
+    }
+
+    public static class CurrentlyPlayingTypeAssertsWrapper extends CurrentlyPlayingTypeAsserts implements ParentAssertAware {
+        private final PlayerStateAssert parent;
+
+        private CurrentlyPlayingTypeAssertsWrapper(String actual, PlayerStateAssert parent) {
+            super(actual);
+            this.parent = parent;
+        }
+
+        @Override
+        public PlayerStateAssert and() {
+            return parent;
+        }
+    }
+}

--- a/src/test/java/testing/asserts/PlayerStateDtoAssert.java
+++ b/src/test/java/testing/asserts/PlayerStateDtoAssert.java
@@ -37,12 +37,12 @@ public class PlayerStateDtoAssert extends AbstractAssert<PlayerStateDtoAssert, P
         return new RepeatStateAssertWrapper(actual.getRepeatState(), this);
     }
 
-    public ShuffleStateAsserts shuffleState() {
-        return new ShuffleStateAsserts(actual.getShuffleState(), this);
+    public ShuffleStateAssertsWrapper shuffleState() {
+        return new ShuffleStateAssertsWrapper(actual.getShuffleState(), this);
     }
 
-    public CurrentlyPlayingTypeAsserts currentlyPlayingType() {
-        return new CurrentlyPlayingTypeAsserts(actual.getCurrentlyPlayingType(), this);
+    public CurrentlyPlayingTypeAssertsWrapper currentlyPlayingType() {
+        return new CurrentlyPlayingTypeAssertsWrapper(actual.getCurrentlyPlayingType(), this);
     }
 
     public PlayerStateDtoAssert progressMs(long expectedMs) {
@@ -89,30 +89,12 @@ public class PlayerStateDtoAssert extends AbstractAssert<PlayerStateDtoAssert, P
         }
     }
 
-    public static class ShuffleStateAsserts extends AbstractAssert<ShuffleStateAsserts, Boolean> implements ParentAssertAware {
+    public static class ShuffleStateAssertsWrapper extends ShuffleStateAsserts implements ParentAssertAware {
         private final PlayerStateDtoAssert parent;
 
-        public static final boolean ON = true;
-        public static final boolean OFF = false;
-
-        public ShuffleStateAsserts(Boolean actual, PlayerStateDtoAssert parent) {
-            super(actual, ShuffleStateAsserts.class);
+        public ShuffleStateAssertsWrapper(Boolean actual, PlayerStateDtoAssert parent) {
+            super(actual);
             this.parent = parent;
-        }
-
-        public ShuffleStateAsserts on() {
-            return shuffleStateAssert(ON);
-        }
-
-        public ShuffleStateAsserts off() {
-            return shuffleStateAssert(OFF);
-        }
-
-        private ShuffleStateAsserts shuffleStateAssert(boolean expected) {
-            if (actual != expected) {
-                failWithActualExpectedAndMessage(actual, expected, "The player state should be: %s(%s)", expected ? "ON" : "OFF", expected);
-            }
-            return this;
         }
 
         @Override
@@ -121,29 +103,12 @@ public class PlayerStateDtoAssert extends AbstractAssert<PlayerStateDtoAssert, P
         }
     }
 
-    public static class CurrentlyPlayingTypeAsserts extends AbstractAssert<CurrentlyPlayingTypeAsserts, String> implements ParentAssertAware {
+    public static class CurrentlyPlayingTypeAssertsWrapper extends CurrentlyPlayingTypeAsserts implements ParentAssertAware {
         private final PlayerStateDtoAssert parent;
-        public static final String TRACK = "track";
-        public static final String PODCAST = "podcast";
 
-        private CurrentlyPlayingTypeAsserts(String actual, PlayerStateDtoAssert parent) {
-            super(actual, CurrentlyPlayingTypeAsserts.class);
+        private CurrentlyPlayingTypeAssertsWrapper(String actual, PlayerStateDtoAssert parent) {
+            super(actual);
             this.parent = parent;
-        }
-
-        public CurrentlyPlayingTypeAsserts track() {
-            return currentPlayingTypeAssert(TRACK);
-        }
-
-        public CurrentlyPlayingTypeAsserts podcast() {
-            return currentPlayingTypeAssert(PODCAST);
-        }
-
-        private CurrentlyPlayingTypeAsserts currentPlayingTypeAssert(String expected) {
-            if (!actual.equals(expected)) {
-                failWithActualExpectedAndMessage(actual, expected, "Expected the playing type to be:");
-            }
-            return this;
         }
 
         @Override

--- a/src/test/java/testing/asserts/ShuffleStateAsserts.java
+++ b/src/test/java/testing/asserts/ShuffleStateAsserts.java
@@ -1,0 +1,27 @@
+package testing.asserts;
+
+import org.assertj.core.api.AbstractAssert;
+
+public  class ShuffleStateAsserts extends AbstractAssert<ShuffleStateAsserts, Boolean> {
+    public static final boolean ON = true;
+    public static final boolean OFF = false;
+
+    public ShuffleStateAsserts(Boolean actual) {
+        super(actual, ShuffleStateAsserts.class);
+    }
+
+    public ShuffleStateAsserts on() {
+        return shuffleStateAssert(ON);
+    }
+
+    public ShuffleStateAsserts off() {
+        return shuffleStateAssert(OFF);
+    }
+
+    private ShuffleStateAsserts shuffleStateAssert(boolean expected) {
+        if (actual != expected) {
+            failWithActualExpectedAndMessage(actual, expected, "The player state should be: %s(%s)", expected ? "ON" : "OFF", expected);
+        }
+        return this;
+    }
+}

--- a/src/test/java/testing/faker/ConnectDeviceRequestFaker.java
+++ b/src/test/java/testing/faker/ConnectDeviceRequestFaker.java
@@ -1,0 +1,49 @@
+package testing.faker;
+
+import com.github.javafaker.Faker;
+import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
+import com.odeyalo.sonata.connect.model.DeviceType;
+import lombok.AccessLevel;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+import org.apache.commons.lang3.RandomStringUtils;
+
+/**
+ * Faker to create close-to-real data for {@link ConnectDeviceRequest}
+ */
+@Setter
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ConnectDeviceRequestFaker {
+    String deviceId;
+    String deviceName;
+    DeviceType deviceType;
+    int volume;
+
+    final Faker faker = Faker.instance();
+
+    protected ConnectDeviceRequestFaker() {
+        this.deviceId = RandomStringUtils.randomAlphanumeric(10);
+        this.deviceName = RandomStringUtils.randomAlphabetic(15);
+        this.deviceType = faker.options().option(DeviceType.class);
+        this.volume = faker.random().nextInt(0, 100);
+    }
+
+    public static ConnectDeviceRequestFaker create() {
+        return new ConnectDeviceRequestFaker();
+    }
+
+    public ConnectDeviceRequest get() {
+        return buildInMemoryDevice();
+    }
+
+
+    private ConnectDeviceRequest buildInMemoryDevice() {
+        return ConnectDeviceRequest
+                .builder()
+                .id(deviceId)
+                .name(deviceName)
+                .deviceType(deviceType)
+                .volume((byte) volume)
+                .build();
+    }
+}

--- a/src/test/java/testing/faker/UserEntityFaker.java
+++ b/src/test/java/testing/faker/UserEntityFaker.java
@@ -2,8 +2,12 @@ package testing.faker;
 
 import com.odeyalo.sonata.connect.entity.InMemoryUserEntity;
 import com.odeyalo.sonata.connect.entity.UserEntity;
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.apache.commons.lang3.RandomStringUtils;
 
+@Setter
+@Accessors(chain = true)
 public class UserEntityFaker {
     String id;
 


### PR DESCRIPTION
Implemented 2 endpoint to change and update the player state.

/player/device/connect - to add the device to connected device list. Device validation is not finished, it will be introduced in one of the next PRs

/player/currently-playing - to get the currently playing object, returns 200 OK if something is playing with body or 204 NO CONTENT if nothing is playing right now.

Written tests for endpoints, service classes.

Added documentation for classes that were without. 

Refactored test assertations. Moved generic asserts to separated classes instead of inner classes.