### PR TITLE
Play endpoint fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <java.version>20</java.version>
         <spring-cloud.version>2022.0.4</spring-cloud.version>
-        <suite.security.version>0.0.1-SNAPSHOT</suite.security.version>
-        <suite.reactive.version>1.0.5</suite.reactive.version>
+        <suite.security.version>1.0.1</suite.security.version>
+        <suite.reactive.version>1.0.6</suite.reactive.version>
         <suite.version>0.0.7</suite.version>
         <javafaker.version>1.0.2</javafaker.version>
     </properties>

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
@@ -66,6 +66,7 @@ public class PlayerStateUpdatePlayCommandHandlerDelegate implements PlayCommandH
     private Mono<PersistablePlayerState> updateAndSave(PersistablePlayerState state, ContextUri contextUri) {
         String trackId = contextUri.getEntityId();
         state.setCurrentlyPlayingItem(TrackItemEntity.of(trackId));
+        state.setPlaying(true);
         return playerStateStorage.save(state);
     }
 

--- a/src/test/java/com/odeyalo/sonata/connect/controller/PlayResumeEndpointPlayerStateControllerTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/PlayResumeEndpointPlayerStateControllerTest.java
@@ -76,6 +76,20 @@ public class PlayResumeEndpointPlayerStateControllerTest {
     }
 
     @Test
+    void shouldSetTrueToPlayingField() {
+        connectDevice();
+
+        String trackUri = "sonata:track:cassie";
+
+        WebTestClient.ResponseSpec responseSpec = sendResumeEndpointRequest(PlayResumePlaybackRequest.of(trackUri));
+
+        PlayerStateDto updatedState = getCurrentState();
+
+        PlayerStateDtoAssert.forState(updatedState)
+                .shouldPlay();
+    }
+
+    @Test
     void shouldReturn400BadRequestIfContextUriMalformed() {
         connectDevice();
         String invalidContextUri = "sonata:somethinginvalid:mikuuuu";


### PR DESCRIPTION
Fixed /play endpoint. 
The flag 'playing' hadn't been updating, now it's fixed and /currently-playing was returning empty 204 status