### PR TITLE
Implemented player synchronization

### DIFF
--- a/src/main/java/com/odeyalo/sonata/connect/config/PlayerOperationsConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/connect/config/PlayerOperationsConfiguration.java
@@ -1,0 +1,29 @@
+package com.odeyalo.sonata.connect.config;
+
+import com.odeyalo.sonata.connect.service.player.BasicPlayerOperations;
+import com.odeyalo.sonata.connect.service.player.DeviceOperations;
+import com.odeyalo.sonata.connect.service.player.EventPublisherDeviceOperationsDecorator;
+import com.odeyalo.sonata.connect.service.player.EventPublisherPlayerOperationsDecorator;
+import com.odeyalo.sonata.connect.service.player.sync.PlayerSynchronizationManager;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class PlayerOperationsConfiguration {
+
+    @Bean
+    @Primary
+    public EventPublisherPlayerOperationsDecorator eventPublisherPlayerOperationsDecorator(BasicPlayerOperations delegate,
+                                                                                           PlayerSynchronizationManager synchronizationManager,
+                                                                                           @Qualifier("eventPublisherDeviceOperations") DeviceOperations deviceOperations) {
+        return new EventPublisherPlayerOperationsDecorator(delegate, synchronizationManager, deviceOperations);
+    }
+
+    @Bean
+    @Primary
+    public EventPublisherDeviceOperationsDecorator eventPublisherDeviceOperations(DeviceOperations delegate, PlayerSynchronizationManager synchronizationManager) {
+        return new EventPublisherDeviceOperationsDecorator(delegate, synchronizationManager);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/config/ReactiveWebSocketConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/connect/config/ReactiveWebSocketConfiguration.java
@@ -1,0 +1,26 @@
+package com.odeyalo.sonata.connect.config;
+
+import com.odeyalo.sonata.connect.service.player.sync.PlayerSynchronizationWebSocketHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+
+import java.util.Map;
+
+/**
+ * Configuration for reactive web sockets
+ */
+@Configuration
+public class ReactiveWebSocketConfiguration {
+    @Autowired
+    PlayerSynchronizationWebSocketHandler playerSynchronizationWebSocketHandler;
+
+    @Bean
+    public HandlerMapping webSocketHandlerMapping() {
+        Map<String, WebSocketHandler> handlers = Map.of("/player/sync", playerSynchronizationWebSocketHandler);
+        return new SimpleUrlHandlerMapping(handlers, -1);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/dto/DeviceConnectedPlayerEventDto.java
+++ b/src/main/java/com/odeyalo/sonata/connect/dto/DeviceConnectedPlayerEventDto.java
@@ -1,0 +1,24 @@
+package com.odeyalo.sonata.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.odeyalo.sonata.connect.service.player.sync.event.DeviceConnectedPlayerEvent;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Dto wrapper for {@link DeviceConnectedPlayerEvent}
+ */
+@Data
+@AllArgsConstructor(staticName = "of")
+public class DeviceConnectedPlayerEventDto extends PlayerEventDto {
+    @JsonProperty("player_state")
+    PlayerStateDto playerState;
+    @JsonProperty("device_that_changed")
+    String deviceThatChanged;
+
+    @Override
+    public PlayerEvent.EventType getEventType() {
+        return PlayerEvent.EventType.NEW_DEVICE_CONNECTED;
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/dto/PlayerEventDto.java
+++ b/src/main/java/com/odeyalo/sonata/connect/dto/PlayerEventDto.java
@@ -1,0 +1,33 @@
+package com.odeyalo.sonata.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Dto representation of {@link PlayerEvent}
+ */
+@Data
+@NoArgsConstructor
+@SuperBuilder
+@FieldDefaults(level = AccessLevel.PROTECTED)
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.EXISTING_PROPERTY,
+        property = "event_type")
+@JsonSubTypes(value = {
+                @JsonSubTypes.Type(value = PlayerStateUpdatedPlayerEventDto.class, name = "PLAYER_STATE_UPDATED"),
+                @JsonSubTypes.Type(value = DeviceConnectedPlayerEventDto.class, name = "NEW_DEVICE_CONNECTED")
+        }
+)
+public abstract class PlayerEventDto {
+
+    @JsonProperty("event_type")
+    public abstract PlayerEvent.EventType getEventType();
+}

--- a/src/main/java/com/odeyalo/sonata/connect/dto/PlayerStateUpdatedPlayerEventDto.java
+++ b/src/main/java/com/odeyalo/sonata/connect/dto/PlayerStateUpdatedPlayerEventDto.java
@@ -1,0 +1,22 @@
+package com.odeyalo.sonata.connect.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Dto wrapper for PlayerStateUpdatedPlayerEvent
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class PlayerStateUpdatedPlayerEventDto extends PlayerEventDto {
+    @JsonProperty("player_state")
+    PlayerStateDto playerState;
+    @JsonProperty("event_type")
+    PlayerEvent.EventType eventType;
+    @JsonProperty("device_that_changed")
+    String deviceThatChanged;
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherDeviceOperationsDecorator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherDeviceOperationsDecorator.java
@@ -1,0 +1,50 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.DeviceModel;
+import com.odeyalo.sonata.connect.model.DevicesModel;
+import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.service.player.sync.PlayerSynchronizationManager;
+import com.odeyalo.sonata.connect.service.player.sync.event.DeviceConnectedPlayerEvent;
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import reactor.core.publisher.Mono;
+
+/**
+ * Decorator that can publish event to PlayerSynchronizationManager
+ */
+public class EventPublisherDeviceOperationsDecorator implements DeviceOperations {
+    private final DeviceOperations delegate;
+    private final PlayerSynchronizationManager synchronizationManager;
+
+    public EventPublisherDeviceOperationsDecorator(DeviceOperations delegate, PlayerSynchronizationManager synchronizationManager) {
+        this.delegate = delegate;
+        this.synchronizationManager = synchronizationManager;
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> addDevice(User user, DeviceModel device) {
+        return delegate.addDevice(user, device)
+                .zipWith(ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication).cast(AuthenticatedUser.class))
+                .flatMap(tuple -> {
+                    CurrentPlayerState state = tuple.getT1();
+                    String deviceId = device.getDeviceId();
+                    return synchronizationManager.publishUpdatedState(tuple.getT2(), DeviceConnectedPlayerEvent.of(state, deviceId))
+                            .thenReturn(state);
+                });
+    }
+
+    @NotNull
+    @Override
+    public Mono<Boolean> containsById(User user, String deviceId) {
+        return delegate.containsById(user, deviceId);
+    }
+
+    @NotNull
+    @Override
+    public Mono<DevicesModel> getConnectedDevices(User user) {
+        return delegate.getConnectedDevices(user);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherPlayerOperationsDecorator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherPlayerOperationsDecorator.java
@@ -1,0 +1,72 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.model.CurrentlyPlayingPlayerState;
+import com.odeyalo.sonata.connect.model.DeviceModel;
+import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.service.player.sync.PlayerSynchronizationManager;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerStateUpdatedPlayerEvent;
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import reactor.core.publisher.Mono;
+import reactor.util.function.Tuple2;
+
+/**
+ * Decorator that can publish event to PlayerSynchronizationManager
+ */
+public class EventPublisherPlayerOperationsDecorator implements BasicPlayerOperations {
+    private final BasicPlayerOperations delegate;
+    private final PlayerSynchronizationManager synchronizationManager;
+    private final DeviceOperations deviceOperations;
+
+    public EventPublisherPlayerOperationsDecorator(BasicPlayerOperations delegate, PlayerSynchronizationManager synchronizationManager, DeviceOperations deviceOperations) {
+        this.delegate = delegate;
+        this.synchronizationManager = synchronizationManager;
+        this.deviceOperations = deviceOperations;
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> currentState(User user) {
+        return delegate.currentState(user)
+                .zipWith(ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication).cast(AuthenticatedUser.class))
+                .flatMap(this::publishEvent);
+    }
+
+    @Override
+    public Mono<CurrentlyPlayingPlayerState> currentlyPlayingState(User user) {
+        return delegate.currentlyPlayingState(user);
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> changeShuffle(User user, boolean shuffleMode) {
+        return delegate.changeShuffle(user, shuffleMode);
+    }
+
+    @Override
+    public DeviceOperations getDeviceOperations() {
+        return deviceOperations;
+    }
+
+    @Override
+    public Mono<CurrentPlayerState> playOrResume(User user, PlayCommandContext context, TargetDevice targetDevice) {
+        return delegate.playOrResume(user, context, targetDevice);
+    }
+
+    @NotNull
+    private Mono<CurrentPlayerState> publishEvent(Tuple2<CurrentPlayerState, AuthenticatedUser> tuple) {
+        CurrentPlayerState currentPlayerState = tuple.getT1();
+        AuthenticatedUser authenticatedUser = tuple.getT2();
+        DeviceModel activeDevice = getActiveDevice(currentPlayerState);
+        if (activeDevice == null) {
+            return Mono.just(currentPlayerState);
+        }
+        return synchronizationManager.publishUpdatedState(authenticatedUser,
+                PlayerStateUpdatedPlayerEvent.of(currentPlayerState, activeDevice.getDeviceId())).thenReturn(currentPlayerState);
+    }
+
+    private static DeviceModel getActiveDevice(CurrentPlayerState state) {
+        return state.getDevices().getDevices().stream().filter(DeviceModel::isActive).findFirst().orElse(null);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/DefaultPlayerSynchronizationManager.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/DefaultPlayerSynchronizationManager.java
@@ -1,0 +1,31 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Default PlayerSynchronizationManager that just delegate job to RoomEventPublisher
+ */
+@Service
+public class DefaultPlayerSynchronizationManager implements PlayerSynchronizationManager {
+    private final RoomHolder roomHolder;
+
+    @Autowired
+    public DefaultPlayerSynchronizationManager(RoomHolder roomHolder) {
+        this.roomHolder = roomHolder;
+    }
+
+    @Override
+    public Mono<Void> publishUpdatedState(AuthenticatedUser user, PlayerEvent event) {
+        return roomHolder.getOrCreateRoom(user).flatMap(room -> room.getPublisher().publishEvent(event));
+    }
+
+    @Override
+    public Flux<PlayerEvent> getEventStream(AuthenticatedUser user) {
+        return roomHolder.getOrCreateRoom(user).flatMapMany(room -> room.getPublisher().getEventStream());
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/InMemoryRoomHolder.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/InMemoryRoomHolder.java
@@ -1,0 +1,32 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static reactor.core.publisher.Mono.fromCallable;
+
+/**
+ * Base implementation that store the values in Map
+ */
+@Component
+public class InMemoryRoomHolder implements RoomHolder {
+    private final Map<String, Room> rooms = new ConcurrentHashMap<>();
+    private final Logger logger = LoggerFactory.getLogger(InMemoryRoomHolder.class);
+
+    @Override
+    public Mono<Room> getOrCreateRoom(AuthenticatedUser user) {
+        Assert.notNull(user, "User cannot be null!");
+        String userId = user.getDetails().getId();
+        return fromCallable(() -> rooms.computeIfAbsent(userId, (key) -> {
+            logger.info("User: {} does not contain ROOM. Creating a new one", user.getDetails().getId());
+            return new Room();
+        }));
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/InMemoryRoomHolder.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/InMemoryRoomHolder.java
@@ -26,7 +26,7 @@ public class InMemoryRoomHolder implements RoomHolder {
         String userId = user.getDetails().getId();
         return fromCallable(() -> rooms.computeIfAbsent(userId, (key) -> {
             logger.info("User: {} does not contain ROOM. Creating a new one", user.getDetails().getId());
-            return new Room();
+            return new SinkRoom();
         }));
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/PlayerSynchronizationManager.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/PlayerSynchronizationManager.java
@@ -1,0 +1,28 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Main interface to synchronize player instance between devices(or clients that can subscribe to events)
+ *
+ * PlayerSynchronizationManager synchronize player instance for every user by making group of devices and synchronize them all at once
+ */
+public interface PlayerSynchronizationManager {
+    /**
+     * Notify about updated state devices ( or other clients )
+     * @param updatedState - new state to notify the devices
+     * @return - void mono
+     */
+    Mono<Void> publishUpdatedState(AuthenticatedUser user, PlayerEvent updatedState);
+
+    /**
+     * Provide access to subscribe to the events, all events will be published to this stream,
+     * stream can be used to subscribe from WebSocket stream, Text-event-stream, etc.
+     * @param user - user to get event stream
+     * @return - unbound hot-flux that provide real-time updates pushed from {@link #publishUpdatedState(AuthenticatedUser, PlayerEvent)}
+     */
+    Flux<PlayerEvent> getEventStream(AuthenticatedUser user);
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/PlayerSynchronizationWebSocketHandler.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/PlayerSynchronizationWebSocketHandler.java
@@ -1,0 +1,72 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.odeyalo.sonata.connect.dto.PlayerEventDto;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import com.odeyalo.sonata.connect.service.support.mapper.Converter;
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Synchronize devices using WebSocket API. Note that websockets in this class used as READ-ONLY and does not support write operation.
+ * Write operations can be done using HTTP endpoints to control playback
+ */
+@Service
+public class PlayerSynchronizationWebSocketHandler implements WebSocketHandler {
+    private final PlayerSynchronizationManager playerSynchronizationManager;
+    private final Converter<PlayerEvent, PlayerEventDto> playerState2PlayerStateDtoConverter;
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public PlayerSynchronizationWebSocketHandler(PlayerSynchronizationManager playerSynchronizationManager,
+                                                 Converter<PlayerEvent, PlayerEventDto> playerState2PlayerStateDtoConverter,
+                                                 ObjectMapper objectMapper) {
+        this.playerSynchronizationManager = playerSynchronizationManager;
+        this.playerState2PlayerStateDtoConverter = playerState2PlayerStateDtoConverter;
+        this.objectMapper = objectMapper;
+    }
+
+    @NotNull
+    @Override
+    public Mono<Void> handle(WebSocketSession session) {
+        Flux<WebSocketMessage> messages = resolveAuthentication()
+                .flatMapMany(user -> receiveAndConvert(session, user));
+        return session.send(messages);
+    }
+
+    @NotNull
+    private Flux<WebSocketMessage> receiveAndConvert(WebSocketSession session, AuthenticatedUser user) {
+        return playerSynchronizationManager.getEventStream(user)
+                .mapNotNull(this::convertAndWriteAsJson)
+                .map(session::textMessage);
+    }
+
+    private String convertAndWriteAsJson(PlayerEvent event) {
+        PlayerEventDto dto = playerState2PlayerStateDtoConverter.convertTo(event);
+        return dto != null ? json(dto) : null;
+    }
+
+    private <T> String json(T dto) {
+        try {
+            return objectMapper.writeValueAsString(dto);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @NotNull
+    private static Mono<AuthenticatedUser> resolveAuthentication() {
+        return ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication)
+                .cast(AuthenticatedUser.class);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/Room.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/Room.java
@@ -1,0 +1,11 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+/**
+ * Interface to represent room.
+ * Note that this interface does not provide info about room members, but just return event publisher for this room
+ */
+public interface Room {
+
+    RoomEventPublisher getPublisher();
+
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/RoomEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/RoomEventPublisher.java
@@ -1,0 +1,15 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Event publisher that used to publish events in specific room
+ */
+public interface RoomEventPublisher {
+
+    Mono<Void> publishEvent(PlayerEvent event);
+
+    Flux<PlayerEvent> getEventStream();
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/RoomHolder.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/RoomHolder.java
@@ -1,0 +1,16 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import reactor.core.publisher.Mono;
+
+/**
+ * A simple holder that holds the room for the AuthenticatedUser. One user has ONLY one room
+ */
+public interface RoomHolder {
+    /**
+     * Retrieve or create a new one room for this user
+     * @param user - user to get or create room to
+     * @return - room wrapped in mono
+     */
+    Mono<Room> getOrCreateRoom(AuthenticatedUser user);
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/SinkRoom.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/SinkRoom.java
@@ -1,0 +1,13 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+/**
+ * Room impl that uses SinkRoomEventPublisher
+ */
+public class SinkRoom implements Room {
+    private final RoomEventPublisher roomEventPublisher = new SinkRoomEventPublisher();
+
+    @Override
+    public RoomEventPublisher getPublisher() {
+        return roomEventPublisher;
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/SinkRoomEventPublisher.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/SinkRoomEventPublisher.java
@@ -1,0 +1,23 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+
+/**
+ * Publish events to multicast sink
+ */
+public class SinkRoomEventPublisher implements RoomEventPublisher {
+    private final Sinks.Many<PlayerEvent> publisher = Sinks.many().multicast().directBestEffort();
+
+    @Override
+    public Mono<Void> publishEvent(PlayerEvent event) {
+        return Mono.just(publisher.tryEmitNext(event)).then();
+    }
+
+    @Override
+    public Flux<PlayerEvent> getEventStream() {
+        return publisher.asFlux();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/event/DeviceConnectedPlayerEvent.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/event/DeviceConnectedPlayerEvent.java
@@ -1,0 +1,38 @@
+package com.odeyalo.sonata.connect.service.player.sync.event;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+import static com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent.EventType.NEW_DEVICE_CONNECTED;
+
+/**
+ * Event to invoke when new device has been connected
+ */
+@Value
+@AllArgsConstructor(staticName = "of")
+@Builder
+public class DeviceConnectedPlayerEvent implements PlayerEvent {
+    CurrentPlayerState playerState;
+    String deviceThatChanged;
+
+    @NotNull
+    @Override
+    public CurrentPlayerState getCurrentPlayerState() {
+        return playerState;
+    }
+
+    @NotNull
+    @Override
+    public EventType getEventType() {
+        return NEW_DEVICE_CONNECTED;
+    }
+
+    @NotNull
+    @Override
+    public String getDeviceThatChanged() {
+        return deviceThatChanged;
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/event/PlayerEvent.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/event/PlayerEvent.java
@@ -1,0 +1,38 @@
+package com.odeyalo.sonata.connect.service.player.sync.event;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Abstract event that can be pushed to the client to notify about update
+ */
+public interface PlayerEvent {
+    /**
+     * @return updated player state for this event
+     */
+    @NotNull
+    CurrentPlayerState getCurrentPlayerState();
+
+    /**
+     * @return event type associated with this event
+     */
+    @NotNull
+    EventType getEventType();
+
+    /**
+     * Return the device that targeted this event, if the event was invoked manually by Oauth2 client without including device ID, then currently active device should be used
+     * @return - device id that targeted event, never null
+     */
+    @NotNull
+    String getDeviceThatChanged();
+
+    /**
+     * List of the player event types to return to the client
+     */
+    enum EventType {
+        PLAYER_STATE_UPDATED,
+        QUEUE_STATE_CHANGED,
+        NEW_DEVICE_CONNECTED,
+        DEVICE_DISAPPEARED
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/sync/event/PlayerStateUpdatedPlayerEvent.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/sync/event/PlayerStateUpdatedPlayerEvent.java
@@ -1,0 +1,44 @@
+package com.odeyalo.sonata.connect.service.player.sync.event;
+
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import org.jetbrains.annotations.NotNull;
+
+import static com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent.EventType.PLAYER_STATE_UPDATED;
+
+/**
+ * Event that can be triggered when player state has been updated(time has been changed, shuffle or repeat mode has been changed, etc.)
+ */
+@Value
+@AllArgsConstructor(staticName = "of", access = AccessLevel.PRIVATE)
+@Builder
+public class PlayerStateUpdatedPlayerEvent implements PlayerEvent {
+    CurrentPlayerState playerState;
+    EventType eventType;
+    String deviceThatChanged;
+
+    public static PlayerStateUpdatedPlayerEvent of(CurrentPlayerState playerState, String deviceThatChanged) {
+        return of(playerState, PLAYER_STATE_UPDATED, deviceThatChanged);
+    }
+
+    @NotNull
+    @Override
+    public CurrentPlayerState getCurrentPlayerState() {
+        return playerState;
+    }
+
+    @NotNull
+    @Override
+    public EventType getEventType() {
+        return eventType;
+    }
+
+    @NotNull
+    @Override
+    public String getDeviceThatChanged() {
+        return deviceThatChanged;
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/support/mapper/dto/HardcodedPlayerEvent2PlayerEventDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/support/mapper/dto/HardcodedPlayerEvent2PlayerEventDtoConverter.java
@@ -1,0 +1,36 @@
+package com.odeyalo.sonata.connect.service.support.mapper.dto;
+
+import com.odeyalo.sonata.connect.dto.DeviceConnectedPlayerEventDto;
+import com.odeyalo.sonata.connect.dto.PlayerEventDto;
+import com.odeyalo.sonata.connect.dto.PlayerStateDto;
+import com.odeyalo.sonata.connect.dto.PlayerStateUpdatedPlayerEventDto;
+import com.odeyalo.sonata.connect.service.player.sync.event.DeviceConnectedPlayerEvent;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerEvent;
+import com.odeyalo.sonata.connect.service.player.sync.event.PlayerStateUpdatedPlayerEvent;
+import com.odeyalo.sonata.connect.service.support.mapper.Converter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HardcodedPlayerEvent2PlayerEventDtoConverter implements Converter<PlayerEvent, PlayerEventDto> {
+    private final CurrentPlayerState2PlayerStateDtoConverter playerState2PlayerStateDtoConverter;
+
+    @Autowired
+    public HardcodedPlayerEvent2PlayerEventDtoConverter(CurrentPlayerState2PlayerStateDtoConverter playerState2PlayerStateDtoConverter) {
+        this.playerState2PlayerStateDtoConverter = playerState2PlayerStateDtoConverter;
+    }
+
+    @Override
+    public PlayerEventDto convertTo(PlayerEvent event) {
+        if (event instanceof PlayerStateUpdatedPlayerEvent e) {
+            PlayerStateDto dto = playerState2PlayerStateDtoConverter.convertTo(e.getPlayerState());
+            return new PlayerStateUpdatedPlayerEventDto(dto, e.getEventType(), e.getDeviceThatChanged());
+        }
+
+        if (event instanceof DeviceConnectedPlayerEvent e) {
+            PlayerStateDto dto = playerState2PlayerStateDtoConverter.convertTo(e.getPlayerState());
+            return DeviceConnectedPlayerEventDto.of(dto, e.getDeviceThatChanged());
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/controller/WebSocketPlayerEventConsumerTests.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/WebSocketPlayerEventConsumerTests.java
@@ -1,0 +1,189 @@
+package com.odeyalo.sonata.connect.controller;
+
+import com.odeyalo.sonata.connect.dto.PlayResumePlaybackRequest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.client.WebSocketClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import testing.faker.ConnectDeviceRequestFaker;
+import testing.shared.SonataTestHttpOperations;
+import testing.spring.autoconfigure.AutoConfigureSonataHttpClient;
+import testing.spring.autoconfigure.AutoConfigureWebSocketClient;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+import static org.springframework.http.HttpHeaders.readOnlyHttpHeaders;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureWebTestClient
+@AutoConfigureWebSocketClient
+@AutoConfigureSonataHttpClient
+@AutoConfigureStubRunner(stubsMode = REMOTE,
+        repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
+        ids = "com.odeyalo.sonata:authorization:+")
+@TestPropertySource(locations = "classpath:application-test.properties")
+public class WebSocketPlayerEventConsumerTests {
+
+    @Autowired
+    WebSocketClient webSocketClient;
+
+    @Autowired
+    SonataTestHttpOperations sonataHttpOperations;
+
+    @LocalServerPort
+    int port;
+
+
+    final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+    final String VALID_USER_ID = "1";
+
+    @BeforeAll
+    void prepare() {
+        Hooks.onOperatorDebug(); // DO NOT DELETE IT, VERY IMPORTANT LINE, WITHOUT IT FEIGN WITH WIREMOCK THROWS ILLEGAL STATE EXCEPTION, I DON'T FIND SOLUTION YET
+    }
+
+    @Test
+    void shouldConnectToWs() {
+        connectToWs(WebSocketSession::close);
+    }
+
+    @Test
+    @Disabled("THIS TEST WORKS RANDOM IDK HOW TO FIX IT")
+    void shouldSendEventIfPlayCommandWasTriggered() {
+        AtomicReference<List<String>> receivedMessages = new AtomicReference<>();
+
+        URI wsUri = URI.create(buildUri());
+        LinkedMultiValueMap<String, String> headers = enhanceHeaders();
+        sonataHttpOperations.connectDevice(VALID_ACCESS_TOKEN, ConnectDeviceRequestFaker.create().get());
+
+        webSocketClient.execute(wsUri,
+                        readOnlyHttpHeaders(headers),
+                        messageConsumer(1, receivedMessages))
+                .and(Mono.fromRunnable(this::resumePlayback))
+                .block(Duration.ofSeconds(5));
+
+        assertThat(receivedMessages.get()).hasSize(1);
+    }
+
+    @Test
+    @Disabled("Don't know how to consume messages from 2 different clients")
+    void shouldSendEventIfPlayCommandWasTriggeredForSpecificRoom() {
+        AtomicReference<List<String>> receivedMessagesClient1 = new AtomicReference<>();
+        AtomicReference<List<String>> receivedMessagesClient2 = new AtomicReference<>();
+
+        URI wsUri = URI.create(buildUri());
+        LinkedMultiValueMap<String, String> headers = enhanceHeaders();
+        sonataHttpOperations.connectDevice(VALID_ACCESS_TOKEN, ConnectDeviceRequestFaker.create().get());
+//
+        Mono.fromRunnable(() -> {
+            System.out.println("Send message");
+            resumePlayback();
+            System.out.println("Sent message");
+        }).and(
+        webSocketClient.execute(wsUri,
+                        readOnlyHttpHeaders(headers),
+                        messageConsumer(1, receivedMessagesClient1)
+                ).doOnSuccess(sub -> System.out.println("Сompleted subcriber 1"))
+                .zipWith(webSocketClient.execute(wsUri,
+                                readOnlyHttpHeaders(headers),
+                                messageConsumer(1, receivedMessagesClient2))
+                        .doOnSuccess(sub -> System.out.println("Сompleted subcriber 2"))))
+                .block(Duration.ofSeconds(5));
+
+        assertThat(receivedMessagesClient2.get()).hasSize(1);
+        assertThat(receivedMessagesClient1.get()).hasSize(1);
+    }
+
+    @Test
+    @Disabled("Disabled because it was written for example only and will be rewritten later")
+    void shouldReceiveEvents() {
+
+        Flux<String> input = Flux.just("Hello", "World", "I", "Love", "Miku");
+        AtomicReference<List<String>> receivedMessagesClient1 = new AtomicReference<>();
+        AtomicReference<List<String>> receivedMessagesClient2 = new AtomicReference<>();
+        LinkedMultiValueMap<String, String> headers = enhanceHeaders();
+        URI wsUri = URI.create(buildUri());
+        // HTTP CALL TO PLAY -> UPDATE STATE AND NOTIFY SUBSCRIBERS
+
+        sonataHttpOperations.connectDevice(VALID_ACCESS_TOKEN, ConnectDeviceRequestFaker.create().get());
+
+        webSocketClient.execute(wsUri,
+                        readOnlyHttpHeaders(headers),
+                        messageConsumer(1, receivedMessagesClient1))
+
+                .and(webSocketClient.execute(wsUri,
+                        readOnlyHttpHeaders(headers),
+                        messageConsumer(1, receivedMessagesClient2)))
+                .and(Mono.fromRunnable(this::resumePlayback).then())
+                .block(Duration.ofSeconds(5));
+
+        assertThat(receivedMessagesClient1.get()).hasSize(5);
+        assertThat(receivedMessagesClient2.get()).hasSize(5);
+    }
+
+    private void resumePlayback() {
+        sonataHttpOperations.playOrResumePlayback(VALID_ACCESS_TOKEN, PlayResumePlaybackRequest.of("sonata:track:miku"));
+        System.out.println("resumed playback");
+    }
+
+    @NotNull
+    private static WebSocketHandler messageConsumer(int take, AtomicReference<List<String>> messageReference) {
+        return (session) -> session.receive()
+                .take(take)
+                .map(WebSocketMessage::getPayloadAsText)
+                .doOnNext(payload -> System.out.println("REceived: " + payload + " " + session.getId()))
+                .collectList()
+                .doOnNext(messageReference::set)
+                .then();
+    }
+
+    @NotNull
+    private static WebSocketHandler messageProducer(Flux<String> input) {
+        return (session) -> session.send(input.map(session::textMessage)
+                .doOnNext(text -> System.out.println("Emitted data " + text)));
+    }
+
+    private void connectToWs(WebSocketHandler handler) {
+        String uriString = buildUri();
+        LinkedMultiValueMap<String, String> headers = enhanceHeaders();
+
+        webSocketClient.execute(URI.create(uriString),
+                        readOnlyHttpHeaders(headers),
+                        handler)
+                .block(Duration.ofSeconds(5));
+    }
+
+    @NotNull
+    private LinkedMultiValueMap<String, String> enhanceHeaders() {
+        LinkedMultiValueMap<String, String> headers = new LinkedMultiValueMap<>();
+        headers.add(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN);
+        return headers;
+    }
+
+    private String buildUri() {
+        return String.format("ws://localhost:%s/v1/player/sync", port);
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/sync/InMemoryRoomHolderTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/sync/InMemoryRoomHolderTest.java
@@ -1,0 +1,60 @@
+package com.odeyalo.sonata.connect.service.player.sync;
+
+import com.odeyalo.suite.security.auth.AuthenticatedUser;
+import com.odeyalo.suite.security.auth.AuthenticatedUserDetails;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Set;
+
+import static java.util.Set.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for InMemoryRoomHolder
+ */
+class InMemoryRoomHolderTest {
+
+    @Test
+    void getOrCreateRoom() {
+        InMemoryRoomHolder repository = new InMemoryRoomHolder();
+        AuthenticatedUser user = createAuthenticatedUser();
+        Room room = repository.getOrCreateRoom(user).block();
+
+        assertThat(room).isNotNull();
+    }
+
+    @Test
+    void mustReuseExistingOne() {
+        InMemoryRoomHolder repository = new InMemoryRoomHolder();
+        AuthenticatedUser user = createAuthenticatedUser();
+        Room first = repository.getOrCreateRoom(user).block();
+
+        assertNotNull(first);
+
+        Room second = repository.getOrCreateRoom(user).block();
+
+        assertThat(first).isEqualTo(second);
+    }
+
+    @NotNull
+    private static AuthenticatedUser createAuthenticatedUser() {
+        Set<GrantedAuthority> authorities = of(new SimpleGrantedAuthority("read"), new SimpleGrantedAuthority("write"));
+        AuthenticatedUserDetails details = new AuthenticatedUserDetails("id", "odeyalo", "password", authorities);
+        AuthenticatedUser user = AuthenticatedUser.of(details, "odeyalo", authorities);
+        return user;
+    }
+
+    @Test
+    void shouldThrowException() {
+        InMemoryRoomHolder repository = new InMemoryRoomHolder();
+        assertThatThrownBy(() -> repository.getOrCreateRoom(null).block())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("User cannot be null!");
+
+    }
+}

--- a/src/test/java/testing/shared/SonataTestHttpOperations.java
+++ b/src/test/java/testing/shared/SonataTestHttpOperations.java
@@ -1,0 +1,25 @@
+package testing.shared;
+
+import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
+import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
+import com.odeyalo.sonata.connect.dto.PlayResumePlaybackRequest;
+import com.odeyalo.sonata.connect.dto.PlayerStateDto;
+
+/**
+ * Provide all up-to-update http endpoints that can be done for this microservice.
+ * if anything was changed, then this interface should be updated.
+ *
+ * Note that this is blocking impl that used only for tests only
+ */
+public interface SonataTestHttpOperations {
+
+    PlayerStateDto getCurrentState(String authorizationHeaderValue);
+
+    AvailableDevicesResponseDto getConnectedDevices(String authorizationHeaderValue);
+
+    void connectDevice(String authorizationHeaderValue, ConnectDeviceRequest body);
+
+    void playOrResumePlayback(String authorizationHeaderValue, PlayResumePlaybackRequest body);
+
+    void changeShuffle(String authorizationHeaderValue, boolean shuffleMode);
+}

--- a/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
+++ b/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
@@ -1,0 +1,69 @@
+package testing.shared;
+
+import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
+import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
+import com.odeyalo.sonata.connect.dto.PlayResumePlaybackRequest;
+import com.odeyalo.sonata.connect.dto.PlayerStateDto;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+/**
+ * Call endpoints using WebTestClient
+ */
+public class WebTestClientSonataTestHttpOperations implements SonataTestHttpOperations {
+    private final WebTestClient webTestClient;
+
+    public WebTestClientSonataTestHttpOperations(WebTestClient webTestClient) {
+        this.webTestClient = webTestClient;
+    }
+
+    @Override
+    public PlayerStateDto getCurrentState(String authorizationHeaderValue) {
+        return webTestClient.get()
+                .uri("/player/currently-playing")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
+                .exchange().expectBody(PlayerStateDto.class)
+                .returnResult().getResponseBody();
+    }
+
+    @Override
+    public AvailableDevicesResponseDto getConnectedDevices(String authorizationHeaderValue) {
+        return webTestClient.get()
+                .uri("/player/devices")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
+                .exchange().expectBody(AvailableDevicesResponseDto.class)
+                .returnResult().getResponseBody();
+    }
+
+    @Override
+    public void connectDevice(String authorizationHeaderValue, ConnectDeviceRequest body) {
+        webTestClient.put()
+                .uri("/player/device/connect")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange();
+    }
+
+    @Override
+    public void playOrResumePlayback(String authorizationHeaderValue, PlayResumePlaybackRequest body) {
+        webTestClient.put()
+                .uri("/player/play")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .exchange();
+    }
+
+    @Override
+    public void changeShuffle(String authorizationHeaderValue, boolean shuffleMode) {
+        webTestClient.put()
+                .uri(builder -> {
+                    builder.queryParam("state", shuffleMode);
+                    return builder.path("/player/shuffle").build();
+                })
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
+                .exchange();
+    }
+}

--- a/src/test/java/testing/spring/autoconfigure/AutoConfigureSonataHttpClient.java
+++ b/src/test/java/testing/spring/autoconfigure/AutoConfigureSonataHttpClient.java
@@ -1,0 +1,17 @@
+package testing.spring.autoconfigure;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Auto configure the SonataHttpOperations
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Import(SonataTestHttpOperationsAutoConfiguration.class)
+public @interface AutoConfigureSonataHttpClient {
+}

--- a/src/test/java/testing/spring/autoconfigure/AutoConfigureWebSocketClient.java
+++ b/src/test/java/testing/spring/autoconfigure/AutoConfigureWebSocketClient.java
@@ -1,0 +1,17 @@
+package testing.spring.autoconfigure;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Autoconfigure websockets for tests
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(WebSocketClientTestConfiguration.class)
+public @interface AutoConfigureWebSocketClient {
+}

--- a/src/test/java/testing/spring/autoconfigure/SonataTestHttpOperationsAutoConfiguration.java
+++ b/src/test/java/testing/spring/autoconfigure/SonataTestHttpOperationsAutoConfiguration.java
@@ -1,0 +1,18 @@
+package testing.spring.autoconfigure;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import testing.shared.WebTestClientSonataTestHttpOperations;
+
+/**
+ * Auto-configuration for SonataTestHttpOperations
+ *
+ * @see AutoConfigureSonataHttpClient
+ */
+public class SonataTestHttpOperationsAutoConfiguration {
+
+    @Bean
+    public WebTestClientSonataTestHttpOperations webTestClientSonataTestHttpOperations(WebTestClient webTestClient) {
+        return new WebTestClientSonataTestHttpOperations(webTestClient);
+    }
+}

--- a/src/test/java/testing/spring/autoconfigure/WebSocketClientTestConfiguration.java
+++ b/src/test/java/testing/spring/autoconfigure/WebSocketClientTestConfiguration.java
@@ -1,0 +1,23 @@
+package testing.spring.autoconfigure;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.reactive.socket.client.ReactorNetty2WebSocketClient;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.web.reactive.socket.client.WebSocketClient;
+
+/**
+ * Configuration for WebSocketClient that used for tests
+ */
+public class WebSocketClientTestConfiguration {
+    /**
+     * Create and configure the {@link org.springframework.web.reactive.socket.WebSocketHandler}.
+     * Default implementation is {@link ReactorNetty2WebSocketClient} that is hardcoded.
+     * @return - configured WebSocketClient
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public WebSocketClient webSocketClient() {
+        return new ReactorNettyWebSocketClient();
+    }
+}


### PR DESCRIPTION
Implemented player synchronization using web socket.
Tests are not written for WS only, because i didn't find any good solution for this one. I will investigate it later again.
Currently only 2 operations supported for notification:
- when device connected
 - when playback is resumed using /play endpoint