### PR TITLE
Added HTTP endpoint to disconnect device by its ID

### DIFF
--- a/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
@@ -103,6 +103,13 @@ public class PlayerController {
                 .thenReturn(default204Response());
     }
 
+    @DeleteMapping(value = "/device")
+    public Mono<ResponseEntity<?>> disconnectDevice(@RequestParam("device_id") String deviceId, AuthenticatedUser authenticatedUser) {
+        return playerOperations.getDeviceOperations()
+                .disconnectDevice(resolveUser(authenticatedUser), DisconnectDeviceArgs.withDeviceId(deviceId))
+                .thenReturn(default204Response());
+    }
+
     private CurrentlyPlayingPlayerStateDto convertToDto(CurrentlyPlayingPlayerState state) {
         return currentlyPlayingPlayerStateDtoConverter.convertTo(state);
     }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultStorageDeviceOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultStorageDeviceOperations.java
@@ -57,6 +57,14 @@ public class DefaultStorageDeviceOperations implements DeviceOperations {
 
     @NotNull
     @Override
+    public Mono<CurrentPlayerState> disconnectDevice(User user, DisconnectDeviceArgs args) {
+        return playerStateRepository.findByUserId(user.getId())
+                .doOnNext(playerState -> playerState.getDevices().removeDevice(args.getDeviceId()))
+                .map(currentPlayerStateConverterSupport::convertTo);
+    }
+
+    @NotNull
+    @Override
     public Mono<Devices> getConnectedDevices(User user) {
         return playerStateRepository.findByUserId(user.getId())
                 .map(PlayerState::getDevicesEntity)

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DeviceOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DeviceOperations.java
@@ -31,6 +31,9 @@ public interface DeviceOperations {
     Mono<CurrentPlayerState> transferPlayback(User user, SwitchDeviceCommandArgs args, TargetDeactivationDevices deactivationDevices, TargetDevices targetDevices);
 
     @NotNull
+    Mono<CurrentPlayerState> disconnectDevice(User user, DisconnectDeviceArgs args);
+
+    @NotNull
     Mono<Devices> getConnectedDevices(User user);
 
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DisconnectDeviceArgs.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DisconnectDeviceArgs.java
@@ -1,0 +1,19 @@
+package com.odeyalo.sonata.connect.service.player;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Arguments to disconnect device
+ */
+@Value
+@Builder
+@AllArgsConstructor(staticName = "of")
+public class DisconnectDeviceArgs {
+    String deviceId;
+
+    public static DisconnectDeviceArgs withDeviceId(String deviceId) {
+        return builder().deviceId(deviceId).build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherDeviceOperationsDecorator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherDeviceOperationsDecorator.java
@@ -52,6 +52,12 @@ public class EventPublisherDeviceOperationsDecorator implements DeviceOperations
 
     @NotNull
     @Override
+    public Mono<CurrentPlayerState> disconnectDevice(User user, DisconnectDeviceArgs args) {
+        return delegate.disconnectDevice(user, args);
+    }
+
+    @NotNull
+    @Override
     public Mono<Devices> getConnectedDevices(User user) {
         return delegate.getConnectedDevices(user);
     }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherPlayerOperationsDecorator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/EventPublisherPlayerOperationsDecorator.java
@@ -8,8 +8,6 @@ import com.odeyalo.sonata.connect.service.player.sync.PlayerSynchronizationManag
 import com.odeyalo.sonata.connect.service.player.sync.event.PlayerStateUpdatedPlayerEvent;
 import com.odeyalo.suite.security.auth.AuthenticatedUser;
 import org.jetbrains.annotations.NotNull;
-import org.springframework.security.core.context.ReactiveSecurityContextHolder;
-import org.springframework.security.core.context.SecurityContext;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
@@ -29,9 +27,7 @@ public class EventPublisherPlayerOperationsDecorator implements BasicPlayerOpera
 
     @Override
     public Mono<CurrentPlayerState> currentState(User user) {
-        return delegate.currentState(user)
-                .zipWith(ReactiveSecurityContextHolder.getContext().map(SecurityContext::getAuthentication).cast(AuthenticatedUser.class))
-                .flatMap(this::publishEvent);
+        return delegate.currentState(user);
     }
 
     @Override

--- a/src/test/java/com/odeyalo/sonata/connect/controller/DisconnectDeviceEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/DisconnectDeviceEndpointTest.java
@@ -1,0 +1,94 @@
+package com.odeyalo.sonata.connect.controller;
+
+
+import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
+import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
+import com.odeyalo.sonata.connect.repository.PlayerStateRepository;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Hooks;
+import testing.asserts.AvailableDevicesResponseDtoAssert;
+import testing.faker.ConnectDeviceRequestFaker;
+import testing.shared.SonataTestHttpOperations;
+import testing.spring.autoconfigure.AutoConfigureSonataHttpClient;
+
+import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@AutoConfigureWebTestClient
+@AutoConfigureSonataHttpClient
+@AutoConfigureStubRunner(stubsMode = REMOTE,
+        repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
+        ids = "com.odeyalo.sonata:authorization:+")
+@ActiveProfiles("test")
+public final class DisconnectDeviceEndpointTest {
+    public static final String DISCONNECT_DEVICE_ENDPOINT = "/player/device";
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    SonataTestHttpOperations sonataTestHttpOperations;
+
+    @Autowired
+    PlayerStateRepository playerStateRepository;
+
+    final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
+    final String DEVICE_ID_QUERY_PARAM_NAME = "device_id";
+
+    @BeforeAll
+    void setup() {
+        Hooks.onOperatorDebug(); // DO NOT DELETE IT, VERY IMPORTANT LINE, WITHOUT IT FEIGN WITH WIREMOCK THROWS ILLEGAL STATE EXCEPTION, I DON'T FIND SOLUTION YET
+    }
+
+    @Test
+    void shouldReturnNoContentStatusOnRemovingExistingDevice() {
+        ConnectDeviceRequest existingDevice = ConnectDeviceRequestFaker.create().get();
+        sonataTestHttpOperations.connectDevice(VALID_ACCESS_TOKEN, existingDevice);
+
+        WebTestClient.ResponseSpec responseSpec = sendDisconnectDeviceRequest(existingDevice.getId());
+
+        responseSpec.expectStatus().isNoContent();
+    }
+
+    @Test
+    void shouldRemoveDeviceByItsId() {
+        // given
+        ConnectDeviceRequest existingDevice = ConnectDeviceRequestFaker.create().get();
+        sonataTestHttpOperations.connectDevice(VALID_ACCESS_TOKEN, existingDevice);
+        // when
+        sendDisconnectDeviceRequest(existingDevice.getId());
+        // then
+        AvailableDevicesResponseDto connectedDevices = sonataTestHttpOperations.getConnectedDevices(VALID_ACCESS_TOKEN);
+
+        AvailableDevicesResponseDtoAssert.forBody(connectedDevices).isEmpty();
+    }
+
+    @Test
+    void shouldReturnNoContentStatusOnRemovingNotExistingDevice() {
+        WebTestClient.ResponseSpec responseSpec = sendDisconnectDeviceRequest("not_exist");
+
+        responseSpec.expectStatus().isNoContent();
+    }
+
+    @NotNull
+    private WebTestClient.ResponseSpec sendDisconnectDeviceRequest(@NotNull String deviceId) {
+        return webTestClient.delete()
+                .uri(builder -> builder.path(DISCONNECT_DEVICE_ENDPOINT)
+                        .queryParam(DEVICE_ID_QUERY_PARAM_NAME, deviceId)
+                        .build())
+                .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
+                .exchange();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperationsTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperationsTest.java
@@ -388,6 +388,12 @@ class DefaultPlayerOperationsTest {
 
         @NotNull
         @Override
+        public Mono<CurrentPlayerState> disconnectDevice(User user, DisconnectDeviceArgs args) {
+            return Mono.empty();
+        }
+
+        @NotNull
+        @Override
         public Mono<Devices> getConnectedDevices(User user) {
             return Mono.empty();
         }

--- a/src/test/java/testing/asserts/AvailableDevicesResponseDtoAssert.java
+++ b/src/test/java/testing/asserts/AvailableDevicesResponseDtoAssert.java
@@ -1,9 +1,7 @@
 package testing.asserts;
 
 import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
-import com.odeyalo.sonata.connect.dto.DevicesDto;
 import org.assertj.core.api.AbstractAssert;
-import org.jetbrains.annotations.NotNull;
 
 public class AvailableDevicesResponseDtoAssert extends AbstractAssert<AvailableDevicesResponseDtoAssert, AvailableDevicesResponseDto> {
 
@@ -20,6 +18,10 @@ public class AvailableDevicesResponseDtoAssert extends AbstractAssert<AvailableD
             failWithActualExpectedAndMessage(actual.getSize(), expectedLength, "Expected sizes to be equal");
         }
         return this;
+    }
+
+    public AvailableDevicesResponseDtoAssert isEmpty() {
+        return length(0);
     }
 
     public DevicesDtoAssert devices() {


### PR DESCRIPTION
Added HTTP endpoint to disconnect device by its ID.
Written tests.

Endpoint details:
Method: DELETE
URI: /player/devices
Request parameter: 'device_id' with ID of the device to disconnect 