### PR TITLE
{REFACTOR} Refactored API and service-layer classes

### DIFF
--- a/docs/How-To-Connect-Device.MD
+++ b/docs/How-To-Connect-Device.MD
@@ -5,7 +5,7 @@ Connect device to the player. User can then switch playback to this device.
 #### Request
 
 ```http request
-PUT /player/device/connect
+POST /player/devices
 Authorization: Bearer user_access_token
 ```
 
@@ -38,5 +38,5 @@ Status:
   reason_code' in body, that can be used to determine type of the error
 - 500 Server Error - should never happen, but if so - please, create a new issue that can be used to reproduce the issue
 
-See the [tests](../src/test/java/com/odeyalo/sonata/connect/controller/ConnectDevicePlayerStateControllerTest.java)
+See the [tests](../src/test/java/com/odeyalo/sonata/connect/controller/ConnectDeviceEndpointTest.java)
 for further info

--- a/docs/How-To-Disconnect-Device.MD
+++ b/docs/How-To-Disconnect-Device.MD
@@ -7,7 +7,7 @@ Note: Do nothing if device by provided ID does not exist.
 #### Request
 
 ```http request
-DELETE /player/device
+DELETE /player/devices
 Authorization: Bearer user_access_token
 ```
 

--- a/docs/How-To-Fetch-Connected-Devices.MD
+++ b/docs/How-To-Fetch-Connected-Devices.MD
@@ -65,4 +65,4 @@ Array of the DeviceObject.
 ```
 </details>
 
-See the [tests](../src/test/java/com/odeyalo/sonata/connect/controller/AvailableDevicesPlayerStateControllerTest.java) for further info.
+See the [tests](../src/test/java/com/odeyalo/sonata/connect/controller/FetchAvailableDevicesEndpointTest.java) for further info.

--- a/docs/How-To-Switch-Devices.MD
+++ b/docs/How-To-Switch-Devices.MD
@@ -32,4 +32,4 @@ Status:
 - 400 Bad Request - there is a problem in request or request body. All responses with this status code have 'reason_code' and small description about the error.
 - 500 Server Error - should never happen, but if so - please, create a new GitHub issue that can be used to reproduce the issue 
 
-See the [tests](../src/test/java/com/odeyalo/sonata/connect/controller/DeviceEntitySwitchPlayerControllerTests.java) for further info
+See the [tests](../src/test/java/com/odeyalo/sonata/connect/controller/SwitchDevicesEndpointTest.java) for further info

--- a/docs/How-To-Switch-Devices.MD
+++ b/docs/How-To-Switch-Devices.MD
@@ -6,7 +6,7 @@ Transfer playback to a new device.
 #### Request 
 
 ```http request
-PUT /player/device/switch
+PUT /player/devices
 Authorization: Bearer user_access_token
 ```
 

--- a/src/main/java/com/odeyalo/sonata/connect/config/WebfluxConfiguration.java
+++ b/src/main/java/com/odeyalo/sonata/connect/config/WebfluxConfiguration.java
@@ -1,0 +1,24 @@
+package com.odeyalo.sonata.connect.config;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.codec.Decoder;
+import org.springframework.http.codec.DecoderHttpMessageReader;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.http.codec.json.Jackson2JsonDecoder;
+
+@Configuration
+public class WebfluxConfiguration {
+
+    @Bean
+    public Decoder<?> jackson2JsonDecoder(ObjectMapper mapper) {
+        return new Jackson2JsonDecoder(mapper);
+    }
+
+    @Bean
+    public HttpMessageReader<?> httpMessageReader(Decoder<?> decoder) {
+        return new DecoderHttpMessageReader<>(decoder);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -53,9 +53,10 @@ public class DevicesController {
                 .thenReturn(HttpStatus.default204Response());
     }
 
-    @DeleteMapping(value = "/device")
-    public Mono<ResponseEntity<?>> disconnectDevice(@RequestParam("device_id") String deviceId, User user) {
-        return deviceOperations.disconnectDevice(user, DisconnectDeviceArgs.withDeviceId(deviceId))
+    @DeleteMapping(value = "/device", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<?>> disconnectDevice(@NotNull final DisconnectDeviceArgs disconnectDeviceArgs,
+                                                    @NotNull final User user) {
+        return deviceOperations.disconnectDevice(user, disconnectDeviceArgs)
                 .thenReturn(HttpStatus.default204Response());
     }
 

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -1,0 +1,70 @@
+package com.odeyalo.sonata.connect.controller;
+
+import com.odeyalo.sonata.connect.dto.*;
+import com.odeyalo.sonata.connect.model.*;
+import com.odeyalo.sonata.connect.service.player.*;
+import com.odeyalo.sonata.connect.service.player.sync.TargetDevices;
+import com.odeyalo.sonata.connect.service.support.mapper.dto.ConnectDeviceRequest2DeviceConverter;
+import com.odeyalo.sonata.connect.service.support.mapper.dto.Devices2DevicesDtoConverter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/player")
+@RequiredArgsConstructor
+public class DevicesController {
+    private final DeviceOperations deviceOperations;
+    private final Devices2DevicesDtoConverter devicesDtoConverter;
+    private final ConnectDeviceRequest2DeviceConverter deviceModelConverter;
+
+    @GetMapping("/devices")
+    public Mono<ResponseEntity<?>> getAvailableDevices(User user) {
+        return deviceOperations.getConnectedDevices(user)
+                .map(this::convertToAvailableDevicesResponseDto)
+                .map(body -> ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(body));
+    }
+
+    @PutMapping(value = "/device/connect", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<?>> addDevice(User user,
+                                             @Valid @RequestBody ConnectDeviceRequest body) {
+        Device device = deviceModelConverter.convertTo(body);
+
+        return deviceOperations.addDevice(user, device)
+                .thenReturn(default204Response());
+    }
+
+    @PutMapping(value = "/device/switch", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ResponseEntity<?>> switchDevices(User user, @RequestBody DeviceSwitchRequest body) {
+        return deviceOperations.transferPlayback(
+                        user,
+                        SwitchDeviceCommandArgs.noMatter(),
+                        TargetDeactivationDevices.empty(),
+                        TargetDevices.fromDeviceIds(body.getDeviceIds()))
+                .thenReturn(default204Response());
+    }
+
+    @DeleteMapping(value = "/device")
+    public Mono<ResponseEntity<?>> disconnectDevice(@RequestParam("device_id") String deviceId, User user) {
+        return deviceOperations.disconnectDevice(user, DisconnectDeviceArgs.withDeviceId(deviceId))
+                .thenReturn(default204Response());
+    }
+
+    @NotNull
+    private AvailableDevicesResponseDto convertToAvailableDevicesResponseDto(Devices devices) {
+        DevicesDto devicesDto = devicesDtoConverter.convertTo(devices);
+        return AvailableDevicesResponseDto.of(devicesDto);
+    }
+
+    @NotNull
+    private static ResponseEntity<?> default204Response() {
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -41,7 +41,7 @@ public class DevicesController {
                 .thenReturn(HttpStatus.default204Response());
     }
 
-    @PutMapping(value = "/device/switch", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/devices", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> switchDevices(@NotNull final User user,
                                                  @NotNull final SwitchDeviceCommandArgs switchDeviceCommandArgs,
                                                  @NotNull final TargetDeactivationDevices targetDeactivationDevices,

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -1,16 +1,13 @@
 package com.odeyalo.sonata.connect.controller;
 
-import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
-import com.odeyalo.sonata.connect.dto.DevicesDto;
 import com.odeyalo.sonata.connect.model.Device;
-import com.odeyalo.sonata.connect.model.Devices;
 import com.odeyalo.sonata.connect.model.User;
 import com.odeyalo.sonata.connect.service.player.DeviceOperations;
 import com.odeyalo.sonata.connect.service.player.DisconnectDeviceArgs;
 import com.odeyalo.sonata.connect.service.player.SwitchDeviceCommandArgs;
 import com.odeyalo.sonata.connect.service.player.TargetDeactivationDevices;
 import com.odeyalo.sonata.connect.service.player.sync.TargetDevices;
-import com.odeyalo.sonata.connect.service.support.mapper.dto.Devices2DevicesDtoConverter;
+import com.odeyalo.sonata.connect.service.support.mapper.dto.AvailableDevicesResponseDtoConverter;
 import com.odeyalo.sonata.connect.support.web.HttpStatus;
 import com.odeyalo.sonata.connect.support.web.annotation.ConnectionTarget;
 import com.odeyalo.sonata.connect.support.web.annotation.TransferPlaybackTargets;
@@ -26,12 +23,13 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class DevicesController {
     private final DeviceOperations deviceOperations;
-    private final Devices2DevicesDtoConverter devicesDtoConverter;
+    private final AvailableDevicesResponseDtoConverter availableDevicesConverter;
 
     @GetMapping(value = "/devices", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> getAvailableDevices(@NotNull final User user) {
+
         return deviceOperations.getConnectedDevices(user)
-                .map(this::convertToAvailableDevicesResponseDto)
+                .map(availableDevicesConverter::convertTo)
                 .map(HttpStatus::ok);
     }
 
@@ -61,11 +59,5 @@ public class DevicesController {
                                                     @NotNull final User user) {
         return deviceOperations.disconnectDevice(user, disconnectDeviceArgs)
                 .thenReturn(HttpStatus.default204Response());
-    }
-
-    @NotNull
-    private AvailableDevicesResponseDto convertToAvailableDevicesResponseDto(Devices devices) {
-        DevicesDto devicesDto = devicesDtoConverter.convertTo(devices);
-        return AvailableDevicesResponseDto.of(devicesDto);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -54,7 +54,7 @@ public class DevicesController {
                 .thenReturn(HttpStatus.default204Response());
     }
 
-    @DeleteMapping(value = "/device", produces = MediaType.APPLICATION_JSON_VALUE)
+    @DeleteMapping(value = "/devices", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> disconnectDevice(@NotNull final DisconnectDeviceArgs disconnectDeviceArgs,
                                                     @NotNull final User user) {
         return deviceOperations.disconnectDevice(user, disconnectDeviceArgs)

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -45,10 +45,11 @@ public class DevicesController {
 
     @PutMapping(value = "/device/switch", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> switchDevices(@NotNull final User user,
+                                                 @NotNull final SwitchDeviceCommandArgs switchDeviceCommandArgs,
                                                  @NotNull @TransferPlaybackTargets final TargetDevices transferPlaybackTargets) {
         return deviceOperations.transferPlayback(
                         user,
-                        SwitchDeviceCommandArgs.noMatter(),
+                        switchDeviceCommandArgs,
                         TargetDeactivationDevices.empty(),
                         transferPlaybackTargets)
                 .thenReturn(HttpStatus.default204Response());

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -46,11 +46,12 @@ public class DevicesController {
     @PutMapping(value = "/device/switch", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> switchDevices(@NotNull final User user,
                                                  @NotNull final SwitchDeviceCommandArgs switchDeviceCommandArgs,
+                                                 @NotNull final TargetDeactivationDevices targetDeactivationDevices,
                                                  @NotNull @TransferPlaybackTargets final TargetDevices transferPlaybackTargets) {
         return deviceOperations.transferPlayback(
                         user,
                         switchDeviceCommandArgs,
-                        TargetDeactivationDevices.empty(),
+                        targetDeactivationDevices,
                         transferPlaybackTargets)
                 .thenReturn(HttpStatus.default204Response());
     }

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 @RestController
 @RequestMapping("/player")
@@ -30,6 +31,7 @@ public class DevicesController {
 
         return deviceOperations.getConnectedDevices(user)
                 .map(availableDevicesConverter::convertTo)
+                .subscribeOn(Schedulers.boundedElastic())
                 .map(HttpStatus::ok);
     }
 
@@ -38,6 +40,7 @@ public class DevicesController {
                                              @NotNull @ConnectionTarget final Device device) {
 
         return deviceOperations.addDevice(user, device)
+                .subscribeOn(Schedulers.boundedElastic())
                 .thenReturn(HttpStatus.default204Response());
     }
 
@@ -51,6 +54,7 @@ public class DevicesController {
                         switchDeviceCommandArgs,
                         targetDeactivationDevices,
                         transferPlaybackTargets)
+                .subscribeOn(Schedulers.boundedElastic())
                 .thenReturn(HttpStatus.default204Response());
     }
 
@@ -58,6 +62,7 @@ public class DevicesController {
     public Mono<ResponseEntity<?>> disconnectDevice(@NotNull final DisconnectDeviceArgs disconnectDeviceArgs,
                                                     @NotNull final User user) {
         return deviceOperations.disconnectDevice(user, disconnectDeviceArgs)
+                .subscribeOn(Schedulers.boundedElastic())
                 .thenReturn(HttpStatus.default204Response());
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -1,7 +1,6 @@
 package com.odeyalo.sonata.connect.controller;
 
 import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
-import com.odeyalo.sonata.connect.dto.DeviceSwitchRequest;
 import com.odeyalo.sonata.connect.dto.DevicesDto;
 import com.odeyalo.sonata.connect.model.Device;
 import com.odeyalo.sonata.connect.model.Devices;
@@ -14,6 +13,7 @@ import com.odeyalo.sonata.connect.service.player.sync.TargetDevices;
 import com.odeyalo.sonata.connect.service.support.mapper.dto.Devices2DevicesDtoConverter;
 import com.odeyalo.sonata.connect.support.web.HttpStatus;
 import com.odeyalo.sonata.connect.support.web.annotation.ConnectionTarget;
+import com.odeyalo.sonata.connect.support.web.annotation.TransferPlaybackTargets;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.MediaType;
@@ -44,12 +44,13 @@ public class DevicesController {
     }
 
     @PutMapping(value = "/device/switch", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<?>> switchDevices(User user, @RequestBody DeviceSwitchRequest body) {
+    public Mono<ResponseEntity<?>> switchDevices(@NotNull final User user,
+                                                 @NotNull @TransferPlaybackTargets final TargetDevices transferPlaybackTargets) {
         return deviceOperations.transferPlayback(
                         user,
                         SwitchDeviceCommandArgs.noMatter(),
                         TargetDeactivationDevices.empty(),
-                        TargetDevices.fromDeviceIds(body.getDeviceIds()))
+                        transferPlaybackTargets)
                 .thenReturn(HttpStatus.default204Response());
     }
 

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -1,7 +1,6 @@
 package com.odeyalo.sonata.connect.controller;
 
 import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
-import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
 import com.odeyalo.sonata.connect.dto.DeviceSwitchRequest;
 import com.odeyalo.sonata.connect.dto.DevicesDto;
 import com.odeyalo.sonata.connect.model.Device;
@@ -12,10 +11,9 @@ import com.odeyalo.sonata.connect.service.player.DisconnectDeviceArgs;
 import com.odeyalo.sonata.connect.service.player.SwitchDeviceCommandArgs;
 import com.odeyalo.sonata.connect.service.player.TargetDeactivationDevices;
 import com.odeyalo.sonata.connect.service.player.sync.TargetDevices;
-import com.odeyalo.sonata.connect.service.support.mapper.dto.ConnectDeviceRequest2DeviceConverter;
 import com.odeyalo.sonata.connect.service.support.mapper.dto.Devices2DevicesDtoConverter;
 import com.odeyalo.sonata.connect.support.web.HttpStatus;
-import jakarta.validation.Valid;
+import com.odeyalo.sonata.connect.support.web.annotation.ConnectionTarget;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.MediaType;
@@ -29,7 +27,6 @@ import reactor.core.publisher.Mono;
 public class DevicesController {
     private final DeviceOperations deviceOperations;
     private final Devices2DevicesDtoConverter devicesDtoConverter;
-    private final ConnectDeviceRequest2DeviceConverter deviceModelConverter;
 
     @GetMapping(value = "/devices", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> getAvailableDevices(@NotNull final User user) {
@@ -39,9 +36,8 @@ public class DevicesController {
     }
 
     @PutMapping(value = "/device/connect", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<?>> addDevice(User user,
-                                             @Valid @RequestBody ConnectDeviceRequest body) {
-        Device device = deviceModelConverter.convertTo(body);
+    public Mono<ResponseEntity<?>> addDevice(@NotNull final User user,
+                                             @NotNull @ConnectionTarget final Device device) {
 
         return deviceOperations.addDevice(user, device)
                 .thenReturn(HttpStatus.default204Response());

--- a/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/DevicesController.java
@@ -33,7 +33,7 @@ public class DevicesController {
                 .map(HttpStatus::ok);
     }
 
-    @PutMapping(value = "/device/connect", produces = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/devices", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> addDevice(@NotNull final User user,
                                              @NotNull @ConnectionTarget final Device device) {
 

--- a/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
@@ -40,6 +40,7 @@ public final class PlayerController {
     @GetMapping(value = "/currently-playing", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<CurrentlyPlayingPlayerStateDto>> currentlyPlaying(@NotNull final User user) {
         return playerOperations.currentlyPlayingState(user)
+                .subscribeOn(Schedulers.boundedElastic())
                 .map(currentlyPlayingPlayerStateDtoConverter::convertTo)
                 .map(HttpStatus::ok)
                 .defaultIfEmpty(HttpStatus.default204Response());
@@ -49,12 +50,14 @@ public final class PlayerController {
     public Mono<ResponseEntity<?>> playOrResume(@NotNull final User user,
                                                 @NotNull final PlayCommandContext commandContext) {
         return playerOperations.playOrResume(user, commandContext, null)
+                .subscribeOn(Schedulers.boundedElastic())
                 .thenReturn(HttpStatus.default204Response());
     }
 
     @PutMapping(value = "/pause", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<?>> pause(@NotNull final User user) {
         return playerOperations.pause(user)
+                .subscribeOn(Schedulers.boundedElastic())
                 .thenReturn(HttpStatus.default204Response());
     }
 
@@ -71,6 +74,7 @@ public final class PlayerController {
     public Mono<ResponseEntity<?>> changePlayerVolume(@NotNull final Volume volume,
                                                       @NotNull final User user) {
         return playerOperations.changeVolume(user, volume)
+                .subscribeOn(Schedulers.boundedElastic())
                 .map(it -> HttpStatus.default204Response());
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
@@ -1,7 +1,6 @@
 package com.odeyalo.sonata.connect.controller;
 
 import com.odeyalo.sonata.connect.dto.CurrentlyPlayingPlayerStateDto;
-import com.odeyalo.sonata.connect.dto.PlayResumePlaybackRequest;
 import com.odeyalo.sonata.connect.dto.PlayerStateDto;
 import com.odeyalo.sonata.connect.model.CurrentlyPlayingPlayerState;
 import com.odeyalo.sonata.connect.model.ShuffleMode;
@@ -16,7 +15,10 @@ import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -29,7 +31,7 @@ public class PlayerController {
     private final Converter<CurrentlyPlayingPlayerState, CurrentlyPlayingPlayerStateDto> currentlyPlayingPlayerStateDtoConverter;
 
     @GetMapping(value = "/state", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<PlayerStateDto> currentPlayerState(User user) {
+    public Mono<PlayerStateDto> currentPlayerState(@NotNull final User user) {
 
         return playerOperations.currentState(user)
                 .subscribeOn(Schedulers.boundedElastic())
@@ -37,20 +39,21 @@ public class PlayerController {
     }
 
     @GetMapping(value = "/currently-playing", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<CurrentlyPlayingPlayerStateDto>> currentlyPlaying(User user) {
+    public Mono<ResponseEntity<CurrentlyPlayingPlayerStateDto>> currentlyPlaying(@NotNull final User user) {
         return playerOperations.currentlyPlayingState(user)
                 .map(state -> ResponseEntity.ok(convertToCurrentlyPlayingStateDto(state)))
                 .defaultIfEmpty(HttpStatus.default204Response());
     }
 
     @PutMapping(value = "/play", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<?>> playOrResume(User user, @RequestBody PlayResumePlaybackRequest body) {
-        return playerOperations.playOrResume(user, PlayCommandContext.of(body.getContextUri()), null)
+    public Mono<ResponseEntity<?>> playOrResume(@NotNull final User user,
+                                                @NotNull final PlayCommandContext commandContext) {
+        return playerOperations.playOrResume(user, commandContext, null)
                 .thenReturn(HttpStatus.default204Response());
     }
 
     @PutMapping(value = "/pause", produces = MediaType.APPLICATION_JSON_VALUE)
-    public Mono<ResponseEntity<?>> pause(User user) {
+    public Mono<ResponseEntity<?>> pause(@NotNull final User user) {
         return playerOperations.pause(user)
                 .thenReturn(HttpStatus.default204Response());
     }

--- a/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/controller/PlayerController.java
@@ -25,14 +25,13 @@ import reactor.core.scheduler.Schedulers;
 @RestController
 @RequestMapping("/player")
 @RequiredArgsConstructor
-public class PlayerController {
+public final class PlayerController {
     private final BasicPlayerOperations playerOperations;
     private final CurrentPlayerState2PlayerStateDtoConverter playerState2PlayerStateDtoConverter;
     private final Converter<CurrentlyPlayingPlayerState, CurrentlyPlayingPlayerStateDto> currentlyPlayingPlayerStateDtoConverter;
 
     @GetMapping(value = "/state", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<PlayerStateDto> currentPlayerState(@NotNull final User user) {
-
         return playerOperations.currentState(user)
                 .subscribeOn(Schedulers.boundedElastic())
                 .map(playerState2PlayerStateDtoConverter::convertTo);
@@ -41,7 +40,8 @@ public class PlayerController {
     @GetMapping(value = "/currently-playing", produces = MediaType.APPLICATION_JSON_VALUE)
     public Mono<ResponseEntity<CurrentlyPlayingPlayerStateDto>> currentlyPlaying(@NotNull final User user) {
         return playerOperations.currentlyPlayingState(user)
-                .map(state -> ResponseEntity.ok(convertToCurrentlyPlayingStateDto(state)))
+                .map(currentlyPlayingPlayerStateDtoConverter::convertTo)
+                .map(HttpStatus::ok)
                 .defaultIfEmpty(HttpStatus.default204Response());
     }
 
@@ -72,10 +72,5 @@ public class PlayerController {
                                                       @NotNull final User user) {
         return playerOperations.changeVolume(user, volume)
                 .map(it -> HttpStatus.default204Response());
-    }
-
-    @NotNull
-    private CurrentlyPlayingPlayerStateDto convertToCurrentlyPlayingStateDto(CurrentlyPlayingPlayerState state) {
-        return currentlyPlayingPlayerStateDtoConverter.convertTo(state);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/entity/PlayerStateEntity.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/PlayerStateEntity.java
@@ -3,13 +3,12 @@ package com.odeyalo.sonata.connect.entity;
 import com.odeyalo.sonata.connect.model.PlayingType;
 import com.odeyalo.sonata.connect.model.RepeatState;
 import com.odeyalo.sonata.connect.model.ShuffleMode;
+import com.odeyalo.sonata.connect.model.Volume;
 import lombok.*;
 import lombok.experimental.Accessors;
 import lombok.experimental.FieldDefaults;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.util.Objects;
 
 @Builder
 @Data
@@ -28,12 +27,15 @@ public class PlayerStateEntity {
     Long progressMs = 0L;
     @Nullable
     PlayingType playingType;
-    DevicesEntity devicesEntity;
+    @NotNull
+    @Builder.Default
+    DevicesEntity devicesEntity = DevicesEntity.empty();
     @NotNull
     UserEntity user;
     @Nullable
     PlayableItemEntity currentlyPlayingItem;
-    int volume;
+    @NotNull
+    Volume volume;
     @Getter(value = AccessLevel.PRIVATE)
     @Setter(value = AccessLevel.PRIVATE)
     long playStartTime = 0;
@@ -44,16 +46,13 @@ public class PlayerStateEntity {
     public static final boolean SHUFFLE_ENABLED = true;
     public static final boolean SHUFFLE_DISABLED = false;
 
+    @NotNull
     public ShuffleMode getShuffleState() {
         return shuffleState;
     }
 
     public PlayingType getCurrentlyPlayingType() {
         return playingType;
-    }
-
-    public DevicesEntity getDevicesEntity() {
-        return devicesEntity;
     }
 
     @Nullable
@@ -63,60 +62,5 @@ public class PlayerStateEntity {
 
     public DevicesEntity getDevices() {
         return devicesEntity;
-    }
-
-    public Long getProgressMs() {
-        if (currentlyPlayingItem == null) {
-            return -1L;
-        }
-
-        if ( isPlaying() ) {
-            return progressMs + calculateProgress();
-        }
-        return progressMs;
-
-    }
-
-    private Long calculateProgress() {
-        if ( isPlaying() ) {
-            return System.currentTimeMillis() - playStartTime;
-        } else {
-            return lastPauseTime - playStartTime;
-        }
-    }
-
-    public void playOrResume(PlayableItemEntity item) {
-        if ( currentlyPlayingItem == null || isPaused() ) {
-            setCurrentlyPlayingItem(item);
-            setPlayingType(PlayingType.valueOf(item.getType().name()));
-            setPlaying(true);
-            playStartTime = System.currentTimeMillis();
-            return;
-        }
-
-        if ( !Objects.equals(item.getId(), currentlyPlayingItem.getId()) ) {
-            setCurrentlyPlayingItem(item);
-            setPlayingType(PlayingType.valueOf(item.getType().name()));
-            setPlaying(true);
-            playStartTime = System.currentTimeMillis();
-            progressMs = 0L;
-        }
-    }
-
-    public PlayerStateEntity pause() {
-        if ( isPlaying() ) {
-            setPlaying(false);
-            lastPauseTime = System.currentTimeMillis();
-            progressMs += calculateProgress();
-        }
-        return this;
-    }
-
-    public boolean isPaused() {
-        return !isPlaying();
-    }
-
-    public boolean hasActiveDevice() {
-        return getDevicesEntity().hasActiveDevice();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/entity/factory/DefaultPlayerStateEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/factory/DefaultPlayerStateEntityFactory.java
@@ -38,6 +38,7 @@ public final class DefaultPlayerStateEntityFactory implements PlayerStateEntityF
         if (state.getPlayableItem() != null) {
             final PlayableItemEntity playableItem = playableItemFactory.create(state.getPlayableItem());
             builder.currentlyPlayingItem(playableItem);
+            builder.playingType(state.getPlayingType());
         }
 
         return builder.build();

--- a/src/main/java/com/odeyalo/sonata/connect/entity/factory/DefaultPlayerStateEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/factory/DefaultPlayerStateEntityFactory.java
@@ -26,7 +26,7 @@ public final class DefaultPlayerStateEntityFactory implements PlayerStateEntityF
         final PlayerStateEntity.PlayerStateEntityBuilder builder = PlayerStateEntity.builder()
                 .id(state.getId())
                 .playing(state.isPlaying())
-                .volume(state.getVolume().asInt())
+                .volume(state.getVolume())
                 .repeatState(state.getRepeatState())
                 .shuffleState(state.getShuffleState())
                 .user(UserEntity.builder().id(state.getUser().getId()).build())

--- a/src/main/java/com/odeyalo/sonata/connect/exception/GlobalExceptionHandlerController.java
+++ b/src/main/java/com/odeyalo/sonata/connect/exception/GlobalExceptionHandlerController.java
@@ -4,6 +4,7 @@ import com.odeyalo.sonata.common.context.MalformedContextUriException;
 import com.odeyalo.sonata.connect.dto.ExceptionMessage;
 import com.odeyalo.sonata.connect.dto.ExceptionMessages;
 import com.odeyalo.sonata.connect.dto.ReasonCodeAwareExceptionMessage;
+import com.odeyalo.sonata.connect.exception.web.MissingRequestParameterException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -69,5 +70,11 @@ public class GlobalExceptionHandlerController {
     public ResponseEntity<?> handleInvalidVolumeException(final InvalidVolumeException ex) {
         return ResponseEntity.badRequest()
                 .body(ReasonCodeAwareExceptionMessage.of("invalid_volume", ex.getMessage()));
+    }
+
+    @ExceptionHandler(MissingRequestParameterException.class)
+    public ResponseEntity<?> handleMissingRequestParameterException(final MissingRequestParameterException ex) {
+        return ResponseEntity.badRequest()
+                .body(ExceptionMessage.of(ex.getMessage()));
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/exception/IllegalCommandStateException.java
+++ b/src/main/java/com/odeyalo/sonata/connect/exception/IllegalCommandStateException.java
@@ -1,0 +1,21 @@
+package com.odeyalo.sonata.connect.exception;
+
+/**
+ * An exception that occurred when player state is not satisfied for executing the command.
+ */
+public final class IllegalCommandStateException extends PlayerCommandException {
+    static final String REASON_CODE = "invalid_command_state";
+    static final String MESSAGE = "Player command failed: Player state is not ready to execute this code";
+
+    public IllegalCommandStateException(final String message) {
+        super(message, REASON_CODE);
+    }
+
+    public static IllegalCommandStateException defaultException() {
+        return new IllegalCommandStateException(MESSAGE);
+    }
+
+    public static IllegalCommandStateException withCustomMessage(String message) {
+        return new IllegalCommandStateException(message);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/exception/PlayableItemNotFoundException.java
+++ b/src/main/java/com/odeyalo/sonata/connect/exception/PlayableItemNotFoundException.java
@@ -1,0 +1,17 @@
+package com.odeyalo.sonata.connect.exception;
+
+public final class PlayableItemNotFoundException extends PlayerCommandException {
+    static final String REASON_CODE = "playable_item_not_exist";
+
+    public PlayableItemNotFoundException(final String message) {
+        super(message, REASON_CODE);
+    }
+
+    public static PlayableItemNotFoundException defaultException() {
+        return new PlayableItemNotFoundException("Could not load playable item");
+    }
+
+    public static PlayableItemNotFoundException withCustomMessage(String message) {
+        return new PlayableItemNotFoundException(message);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/exception/web/MissingRequestParameterException.java
+++ b/src/main/java/com/odeyalo/sonata/connect/exception/web/MissingRequestParameterException.java
@@ -1,0 +1,12 @@
+package com.odeyalo.sonata.connect.exception.web;
+
+public final class MissingRequestParameterException extends RuntimeException {
+
+    public MissingRequestParameterException(final String message) {
+        super(message);
+    }
+
+    public MissingRequestParameterException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -2,10 +2,14 @@ package com.odeyalo.sonata.connect.model;
 
 import com.odeyalo.sonata.connect.service.player.TargetDeactivationDevice;
 import com.odeyalo.sonata.connect.service.player.TargetDevice;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -38,7 +42,9 @@ public class CurrentPlayerState {
     @NotNull
     @Builder.Default
     Volume volume = Volume.muted();
+    @Builder.Default
     long lastPauseTime = 0;
+    @Builder.Default
     long playStartTime = 0;
 
     @NotNull
@@ -103,5 +109,30 @@ public class CurrentPlayerState {
         final var updatedDevices = devices.transferPlayback(deviceToTransferPlayback);
 
         return withDevices(updatedDevices);
+    }
+
+    public CurrentPlayerState playOrResume(@Nullable final PlayableItem item) {
+        CurrentPlayerStateBuilder builder = this.toBuilder();
+
+        if ( item == null || !isPlaying() ) {
+            return builder
+                    .playableItem(item)
+                    .playingType(PlayingType.valueOf(item.getItemType().name()))
+                    .playing(true)
+                    .playStartTime(System.currentTimeMillis())
+                    .build();
+        }
+
+        if ( !Objects.equals(item.getId(), playableItem.getId()) ) {
+            return builder
+                    .playableItem(item)
+                    .playingType(PlayingType.valueOf(item.getItemType().name()))
+                    .playing(true)
+                    .playStartTime(System.currentTimeMillis())
+                    .progressMs(0L)
+                    .build();
+        }
+
+        return this;
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -27,8 +27,8 @@ public class CurrentPlayerState {
     @NotNull
     @Builder.Default
     ShuffleMode shuffleState = ShuffleMode.OFF;
-    @Nullable
-    Long progressMs;
+    @Builder.Default
+    long progressMs = -1L;
     @Nullable
     PlayingType playingType;
     @NotNull
@@ -97,6 +97,17 @@ public class CurrentPlayerState {
         return playableItem != null;
     }
 
+    public long getProgressMs() {
+        if ( playableItem == null ) {
+            return -1L;
+        }
+
+        if ( isPlaying() ) {
+            return progressMs + calculateProgress();
+        }
+        return progressMs;
+    }
+
     @NotNull
     public CurrentPlayerState disconnectDevice(@NotNull final String deviceId) {
         final TargetDeactivationDevice deactivationTarget = TargetDeactivationDevice.of(deviceId);
@@ -139,5 +150,26 @@ public class CurrentPlayerState {
                 .playing(true)
                 .playStartTime(System.currentTimeMillis())
                 .build();
+    }
+
+    @NotNull
+    public CurrentPlayerState pause() {
+        if ( isPlaying() ) {
+            return this.toBuilder()
+                    .playing(false)
+                    .lastPauseTime(System.currentTimeMillis())
+                    .progressMs(progressMs + calculateProgress())
+                    .build();
+        }
+
+        return this;
+    }
+
+    private long calculateProgress() {
+        if ( isPlaying() ) {
+            return System.currentTimeMillis() - playStartTime;
+        } else {
+            return lastPauseTime - playStartTime;
+        }
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -9,7 +9,6 @@ import lombok.With;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
 import java.util.Random;
 
 /**
@@ -111,28 +110,22 @@ public class CurrentPlayerState {
         return withDevices(updatedDevices);
     }
 
-    public CurrentPlayerState playOrResume(@Nullable final PlayableItem item) {
-        CurrentPlayerStateBuilder builder = this.toBuilder();
+    @NotNull
+    public CurrentPlayerState play(@NotNull final PlayableItem item) {
+        return this.toBuilder()
+                .playing(true)
+                .playableItem(item)
+                .playingType(PlayingType.valueOf(item.getItemType().name()))
+                .playStartTime(System.currentTimeMillis())
+                .progressMs(0L)
+                .build();
+    }
 
-        if ( item == null || !isPlaying() ) {
-            return builder
-                    .playableItem(item)
-                    .playingType(PlayingType.valueOf(item.getItemType().name()))
-                    .playing(true)
-                    .playStartTime(System.currentTimeMillis())
-                    .build();
-        }
-
-        if ( !Objects.equals(item.getId(), playableItem.getId()) ) {
-            return builder
-                    .playableItem(item)
-                    .playingType(PlayingType.valueOf(item.getItemType().name()))
-                    .playing(true)
-                    .playStartTime(System.currentTimeMillis())
-                    .progressMs(0L)
-                    .build();
-        }
-
-        return this;
+    @NotNull
+    public CurrentPlayerState resumePlayback() {
+        return this.toBuilder()
+                .playing(true)
+                .playStartTime(System.currentTimeMillis())
+                .build();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -85,6 +85,18 @@ public class CurrentPlayerState {
         return devices.hasDevice(searchTarget);
     }
 
+    public boolean missingPlayingItem() {
+        return playableItem == null;
+    }
+
+    public boolean missingActiveDevice() {
+        return !hasActiveDevice();
+    }
+
+    public boolean hasPlayingItem() {
+        return playableItem != null;
+    }
+
     @NotNull
     public CurrentPlayerState disconnectDevice(@NotNull final String deviceId) {
         final TargetDeactivationDevice deactivationTarget = TargetDeactivationDevice.of(deviceId);

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/BasicPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/BasicPlayerOperations.java
@@ -68,7 +68,7 @@ public interface BasicPlayerOperations {
      */
     @NotNull
     Mono<CurrentPlayerState> playOrResume(@NotNull User user,
-                                          @Nullable PlayCommandContext context,
+                                          @NotNull PlayCommandContext context,
                                           @Nullable TargetDevice targetDevice);
 
     /**

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperations.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/DefaultPlayerOperations.java
@@ -60,7 +60,7 @@ public final class DefaultPlayerOperations implements BasicPlayerOperations {
     @Override
     @NotNull
     public Mono<CurrentPlayerState> playOrResume(@NotNull final User user,
-                                                 @Nullable final PlayCommandContext context,
+                                                 @NotNull final PlayCommandContext context,
                                                  @Nullable final TargetDevice targetDevice) {
         return playCommandHandlerDelegate.playOrResume(user, context, targetDevice);
     }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/PlayCommandContext.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/PlayCommandContext.java
@@ -25,4 +25,8 @@ public class PlayCommandContext {
     public static PlayCommandContext from(@NotNull ContextUri contextUri) {
         return of(contextUri);
     }
+
+    public boolean shouldBeResumed() {
+        return contextUri == null;
+    }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/PlayCommandContext.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/PlayCommandContext.java
@@ -3,6 +3,7 @@ package com.odeyalo.sonata.connect.service.player;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Provide info for Play command that should be played now
@@ -13,4 +14,8 @@ import lombok.Value;
 public class PlayCommandContext {
     // Context URI to start play, supported types are: track, playlist, album, artist.
     String contextUri;
+
+    public static PlayCommandContext from(@NotNull String contextUri) {
+        return of(contextUri);
+    }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/PlayCommandContext.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/PlayCommandContext.java
@@ -1,9 +1,11 @@
 package com.odeyalo.sonata.connect.service.player;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Provide info for Play command that should be played now
@@ -12,10 +14,15 @@ import org.jetbrains.annotations.NotNull;
 @AllArgsConstructor(staticName = "of")
 @Builder
 public class PlayCommandContext {
-    // Context URI to start play, supported types are: track, playlist, album, artist.
-    String contextUri;
+    @Nullable
+    ContextUri contextUri;
 
-    public static PlayCommandContext from(@NotNull String contextUri) {
+    @NotNull
+    public static PlayCommandContext resumePlayback() {
+        return new PlayCommandContext(null);
+    }
+
+    public static PlayCommandContext from(@NotNull ContextUri contextUri) {
         return of(contextUri);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayCommandHandlerDelegate.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayCommandHandlerDelegate.java
@@ -7,6 +7,8 @@ import com.odeyalo.sonata.connect.model.User;
 import com.odeyalo.sonata.connect.service.player.BasicPlayerOperations;
 import com.odeyalo.sonata.connect.service.player.PlayCommandContext;
 import com.odeyalo.sonata.connect.service.player.TargetDevice;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
 /**
@@ -14,13 +16,19 @@ import reactor.core.publisher.Mono;
  */
 public interface PlayCommandHandlerDelegate {
     /**
-     * Play or resume track or episode(or any PlayableItem) playback. Return the updated state as result
-     * @param user - current user to start play
-     * @param context - context with play request payload
-     * @param targetDevice - device to start playing to
+     * Play or resume player playback based on {@link PlayCommandContext}.
+     * Return the updated state as result
+     *
+     * @param user         - current user to start play
+     * @param context      - context with play request payload
+     * @param targetDevice - device to start playing to, if null supplied, then currently active device will start play
+     * @return - updated {@link CurrentPlayerState}
      * @throws ReasonCodeAwareMalformedContextUriException - if context contains invalid context-uri
-     * @throws NoActiveDeviceException - if state for the user does not contain active device.
-     * @return - updated CurrentPlayerState
+     * @throws NoActiveDeviceException                     - if state for the user does not contain active device.
+     * @throws com.odeyalo.sonata.connect.exception.PlayerCommandException - if the command is malformed
      */
-    Mono<CurrentPlayerState> playOrResume(User user, PlayCommandContext context, TargetDevice targetDevice);
+    @NotNull
+    Mono<CurrentPlayerState> playOrResume(@NotNull User user,
+                                          @NotNull PlayCommandContext context,
+                                          @Nullable TargetDevice targetDevice);
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
@@ -72,9 +72,9 @@ public class PlayerStateUpdatePlayCommandHandlerDelegate implements PlayCommandH
     }
 
     @NotNull
-    private Mono<CurrentPlayerState> validateCommand(@Nullable final PlayCommandContext context,
+    private Mono<CurrentPlayerState> validateCommand(@NotNull final PlayCommandContext context,
                                                      @NotNull final CurrentPlayerState state) {
         return integrityValidator.validate(context, state)
-                .flatMap(result -> result.isValid() ? Mono.just(state) : Mono.error(result.getOccurredException()));
+                .thenReturn(state);
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
@@ -1,7 +1,5 @@
 package com.odeyalo.sonata.connect.service.player.handler;
 
-import com.odeyalo.sonata.common.context.ContextUri;
-import com.odeyalo.sonata.common.context.MalformedContextUriException;
 import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.model.PlayableItem;
 import com.odeyalo.sonata.connect.model.User;
@@ -42,10 +40,10 @@ public class PlayerStateUpdatePlayCommandHandlerDelegate implements PlayCommandH
     }
 
     @NotNull
-    private Mono<CurrentPlayerState> save(PlayCommandContext context, CurrentPlayerState state) throws MalformedContextUriException {
-        ContextUri contextUri = ContextUri.fromString(context.getContextUri());
+    private Mono<CurrentPlayerState> save(@NotNull final PlayCommandContext context,
+                                          @NotNull final CurrentPlayerState state) {
 
-        return playableItemLoader.loadPlayableItem(contextUri)
+        return playableItemLoader.loadPlayableItem(context.getContextUri())
                 .flatMap(item -> updateAndSavePlayerState(state, item));
     }
 
@@ -58,7 +56,7 @@ public class PlayerStateUpdatePlayCommandHandlerDelegate implements PlayCommandH
     }
 
     @NotNull
-    private Mono<CurrentPlayerState> validateCommand(@NotNull final PlayCommandContext context,
+    private Mono<CurrentPlayerState> validateCommand(@Nullable final PlayCommandContext context,
                                                      @NotNull final CurrentPlayerState state) {
         return integrityValidator.validate(context, state)
                 .flatMap(result -> result.isValid() ? Mono.just(state) : Mono.error(result.getOccurredException()));

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/HardCodedPauseCommandPreExecutingIntegrityValidator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/HardCodedPauseCommandPreExecutingIntegrityValidator.java
@@ -1,7 +1,7 @@
 package com.odeyalo.sonata.connect.service.player.support.validation;
 
-import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
 import com.odeyalo.sonata.connect.exception.NoActiveDeviceException;
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
@@ -11,15 +11,12 @@ public final class HardCodedPauseCommandPreExecutingIntegrityValidator implement
 
     @Override
     @NotNull
-    public Mono<PlayerCommandIntegrityValidationResult> validate(@NotNull PlayerStateEntity currentState) {
-        boolean hasActiveDevice = currentState.getDevicesEntity().hasActiveDevice();
+    public Mono<Void> validate(@NotNull final CurrentPlayerState currentState) {
 
-        if ( !hasActiveDevice ) {
-            return Mono.just(
-                    PlayerCommandIntegrityValidationResult.invalid(new NoActiveDeviceException())
-            );
+        if ( currentState.missingActiveDevice() ) {
+            return Mono.error(NoActiveDeviceException::defaultException);
         }
 
-        return Mono.just(PlayerCommandIntegrityValidationResult.valid());
+        return Mono.empty();
     }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/HardcodedPlayCommandPreExecutingIntegrityValidator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/HardcodedPlayCommandPreExecutingIntegrityValidator.java
@@ -1,9 +1,9 @@
 package com.odeyalo.sonata.connect.service.player.support.validation;
 
 import com.odeyalo.sonata.common.context.ContextUri;
-import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
 import com.odeyalo.sonata.connect.exception.NoActiveDeviceException;
 import com.odeyalo.sonata.connect.exception.ReasonCodeAwareMalformedContextUriException;
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.service.player.PlayCommandContext;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
@@ -18,13 +18,13 @@ import reactor.core.publisher.Mono;
 public class HardcodedPlayCommandPreExecutingIntegrityValidator implements PlayCommandPreExecutingIntegrityValidator {
 
     @Override
-    public Mono<PlayerCommandIntegrityValidationResult> validate(@NotNull PlayCommandContext context, PlayerStateEntity currentState) {
-        if ( currentState.getDevicesEntity().size() == 0 ) {
+    public Mono<PlayerCommandIntegrityValidationResult> validate(@NotNull PlayCommandContext context, CurrentPlayerState currentState) {
+        if ( currentState.getDevices().size() == 0 ) {
             NoActiveDeviceException ex = new NoActiveDeviceException("There is no active device");
             return Mono.just(PlayerCommandIntegrityValidationResult.invalid(ex));
         }
 
-        if ( context.getContextUri() == null && currentState.getCurrentlyPlayingItem() == null ) {
+        if ( context.getContextUri() == null && currentState.getPlayingItem() == null ) {
             IllegalStateException ex = new IllegalStateException("Nothing is playing now and context is null!");
             return Mono.just(PlayerCommandIntegrityValidationResult.invalid(ex));
         }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/HardcodedPlayCommandPreExecutingIntegrityValidator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/HardcodedPlayCommandPreExecutingIntegrityValidator.java
@@ -1,8 +1,6 @@
 package com.odeyalo.sonata.connect.service.player.support.validation;
 
-import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.connect.exception.NoActiveDeviceException;
-import com.odeyalo.sonata.connect.exception.ReasonCodeAwareMalformedContextUriException;
 import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.service.player.PlayCommandContext;
 import org.jetbrains.annotations.NotNull;
@@ -27,13 +25,6 @@ public class HardcodedPlayCommandPreExecutingIntegrityValidator implements PlayC
         if ( context.getContextUri() == null && currentState.getPlayingItem() == null ) {
             IllegalStateException ex = new IllegalStateException("Nothing is playing now and context is null!");
             return Mono.just(PlayerCommandIntegrityValidationResult.invalid(ex));
-        }
-
-
-        if ( context.getContextUri() != null && !ContextUri.isValid(context.getContextUri()) ) {
-            final var exception = new ReasonCodeAwareMalformedContextUriException("Context uri is malformed", context.getContextUri());
-
-            return Mono.just(PlayerCommandIntegrityValidationResult.invalid(exception));
         }
 
         return Mono.just(PlayerCommandIntegrityValidationResult.valid());

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/PauseCommandPreExecutingIntegrityValidator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/PauseCommandPreExecutingIntegrityValidator.java
@@ -1,20 +1,19 @@
 package com.odeyalo.sonata.connect.service.player.support.validation;
 
-import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
 /**
- * Contract to validate pause command data before its being executes
+ * Contract to validate pause command before its being executes
  */
 public interface PauseCommandPreExecutingIntegrityValidator {
     /**
-     * Validate the given parameters, returns result based on this
+     * Validate the state before executing the pause command
      * @param currentState - current state associated with user
-     * @return - {@link Mono with {@link PlayerCommandIntegrityValidationResult#valid()} if context is valid,
-     * otherwise {@link Mono} with {@link PlayerCommandIntegrityValidationResult#invalid}
+     * @return - {@link Mono} with {@link Void} on success, or {@link Mono#error(Throwable)} with an error
      */
     @NotNull
-    Mono<PlayerCommandIntegrityValidationResult> validate(@NotNull PlayerStateEntity currentState);
+    Mono<Void> validate(@NotNull CurrentPlayerState currentState);
 
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/PlayCommandPreExecutingIntegrityValidator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/PlayCommandPreExecutingIntegrityValidator.java
@@ -1,6 +1,6 @@
 package com.odeyalo.sonata.connect.service.player.support.validation;
 
-import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
+import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.service.player.PlayCommandContext;
 import reactor.core.publisher.Mono;
 
@@ -14,6 +14,6 @@ public interface PlayCommandPreExecutingIntegrityValidator {
      * @param currentState - current state associated with user
      * @return - PlayCommandIntegrityValidationResult#valid if context is valid, otherwise PlayCommandIntegrityValidationResult#invalid 
      */
-    Mono<PlayerCommandIntegrityValidationResult> validate(PlayCommandContext context, PlayerStateEntity currentState);
+    Mono<PlayerCommandIntegrityValidationResult> validate(PlayCommandContext context, CurrentPlayerState currentState);
 
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/PlayCommandPreExecutingIntegrityValidator.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/support/validation/PlayCommandPreExecutingIntegrityValidator.java
@@ -2,18 +2,21 @@ package com.odeyalo.sonata.connect.service.player.support.validation;
 
 import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.service.player.PlayCommandContext;
+import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
 /**
- * Interface to validate the Play command data before its executes
+ * Contract to validate play or resume command before it is being executed
  */
 public interface PlayCommandPreExecutingIntegrityValidator {
     /**
-     * Validate the given parameters, returns result based on this
-     * @param context - context to validate
-     * @param currentState - current state associated with user
-     * @return - PlayCommandIntegrityValidationResult#valid if context is valid, otherwise PlayCommandIntegrityValidationResult#invalid 
+     * Validate the given arguments before executing play or resume playback command
+     *
+     * @param context      - a play command context that contains info about command
+     * @param currentState - current state associated with user, before executing this command
+     * @return - {@link Mono} with the {@link Void} on success or {@link  Mono#error(Throwable) } with an error that occurred
      */
-    Mono<PlayerCommandIntegrityValidationResult> validate(PlayCommandContext context, CurrentPlayerState currentState);
-
+    @NotNull
+    Mono<Void> validate(@NotNull PlayCommandContext context,
+                        @NotNull CurrentPlayerState currentState);
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/support/mapper/PlayerState2CurrentPlayerStateConverter.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/support/mapper/PlayerState2CurrentPlayerStateConverter.java
@@ -20,7 +20,7 @@ import org.mapstruct.Mapping;
 public interface PlayerState2CurrentPlayerStateConverter extends Converter<PlayerStateEntity, CurrentPlayerState> {
 
     @Mapping(target = "playableItem", source = "currentlyPlayingItem")
-    @Mapping(target = "volume", expression = "java( Volume.from(state.getVolume()) )")
+    @Mapping(target = "volume", expression = "java( state.getVolume() )")
     CurrentPlayerState convertTo(PlayerStateEntity state);
 
 }

--- a/src/main/java/com/odeyalo/sonata/connect/service/support/mapper/dto/AvailableDevicesResponseDtoConverter.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/support/mapper/dto/AvailableDevicesResponseDtoConverter.java
@@ -1,0 +1,22 @@
+package com.odeyalo.sonata.connect.service.support.mapper.dto;
+
+import com.odeyalo.sonata.connect.dto.AvailableDevicesResponseDto;
+import com.odeyalo.sonata.connect.dto.DevicesDto;
+import com.odeyalo.sonata.connect.model.Devices;
+import org.mapstruct.Mapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+@Mapper(componentModel = SPRING, uses = {
+        Devices2DevicesDtoConverter.class
+})
+public abstract class AvailableDevicesResponseDtoConverter {
+    @Autowired
+    Devices2DevicesDtoConverter devices2DevicesDtoConverter;
+
+    public AvailableDevicesResponseDto convertTo(Devices devices) {
+        final DevicesDto devicesDto = devices2DevicesDtoConverter.convertTo(devices);
+        return AvailableDevicesResponseDto.of(devicesDto);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/HttpStatus.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/HttpStatus.java
@@ -1,0 +1,22 @@
+package com.odeyalo.sonata.connect.support.web;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+public final class HttpStatus {
+
+
+    @NotNull
+    public static <T> ResponseEntity<T> default204Response() {
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @NotNull
+    public static <T> ResponseEntity<T> ok(@NotNull final T body) {
+        return ResponseEntity.ok(body);
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/annotation/ConnectionTarget.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/annotation/ConnectionTarget.java
@@ -1,0 +1,16 @@
+package com.odeyalo.sonata.connect.support.web.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Custom annotation that used to annotate the parameters of type {@link com.odeyalo.sonata.connect.model.Device}
+ * to parse request body by {@link com.odeyalo.sonata.connect.support.web.resolver.DeviceResolver}.
+ */
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface ConnectionTarget {
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/annotation/TransferPlaybackTargets.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/annotation/TransferPlaybackTargets.java
@@ -1,0 +1,12 @@
+package com.odeyalo.sonata.connect.support.web.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target(PARAMETER)
+public @interface TransferPlaybackTargets {
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/DeviceResolver.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/DeviceResolver.java
@@ -1,0 +1,68 @@
+package com.odeyalo.sonata.connect.support.web.resolver;
+
+import com.odeyalo.sonata.connect.dto.ConnectDeviceRequest;
+import com.odeyalo.sonata.connect.model.Device;
+import com.odeyalo.sonata.connect.service.support.mapper.dto.ConnectDeviceRequest2DeviceConverter;
+import com.odeyalo.sonata.connect.support.web.annotation.ConnectionTarget;
+import jakarta.validation.Valid;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.annotation.AbstractMessageReaderArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+/**
+ * A custom resolver that resolves a {@link Device} from the given {@link ServerWebExchange}.
+ * Only methods of type {@link Device} annotated with {@link ConnectionTarget} will be processed.
+ */
+@Component
+public final class DeviceResolver extends AbstractMessageReaderArgumentResolver {
+    private final ConnectDeviceRequest2DeviceConverter deviceModelConverter;
+
+    public DeviceResolver(final List<HttpMessageReader<?>> readers,
+                          final ConnectDeviceRequest2DeviceConverter deviceModelConverter) {
+        super(readers);
+        this.deviceModelConverter = deviceModelConverter;
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(Device.class) &&
+                parameter.hasParameterAnnotation(ConnectionTarget.class);
+    }
+
+    @Override
+    @NotNull
+    public Mono<Object> resolveArgument(@NotNull final MethodParameter parameter,
+                                        @NotNull final BindingContext bindingContext,
+                                        @NotNull final ServerWebExchange exchange) {
+
+        final Parameter bodyTypeParameter = resolveBodyTypeParameter();
+
+        return readBody(MethodParameter.forParameter(bodyTypeParameter), parameter, true, bindingContext, exchange)
+                .cast(ConnectDeviceRequest.class)
+                .map(deviceModelConverter::convertTo);
+    }
+
+    private Parameter resolveBodyTypeParameter() {
+        //noinspection DataFlowIssue never be null because we always have method in this class
+        return ReflectionUtils
+                .findMethod(this.getClass(), "methodParameterDescriptorSupport", ConnectDeviceRequest.class)
+                .getParameters()[0];
+    }
+    /**
+     * Support method to resolve {@link Parameter} to set in {@link MethodParameter}
+     * DO NOT DELETE IT IN ANY CASE, ONLY IF YOU FOUND A BETTER SOLUTION
+     *
+     * @param body - body class to read content to
+     */
+    @SuppressWarnings("unused")
+    private void methodParameterDescriptorSupport(@Valid ConnectDeviceRequest body) {
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/DisconnectDeviceArgsResolver.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/DisconnectDeviceArgsResolver.java
@@ -1,0 +1,42 @@
+package com.odeyalo.sonata.connect.support.web.resolver;
+
+import com.odeyalo.sonata.connect.exception.web.MissingRequestParameterException;
+import com.odeyalo.sonata.connect.service.player.DisconnectDeviceArgs;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public final class DisconnectDeviceArgsResolver implements HandlerMethodArgumentResolver {
+
+    public static final String DEVICE_ID_KEY = "device_id";
+
+    @Override
+    public boolean supportsParameter(@NotNull final MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(DisconnectDeviceArgs.class);
+    }
+
+    @Override
+    @NotNull
+    public Mono<Object> resolveArgument(@NotNull final MethodParameter parameter,
+                                        @NotNull final BindingContext bindingContext,
+                                        @NotNull final ServerWebExchange exchange) {
+
+        final String deviceId = exchange.getRequest().getQueryParams().getFirst(DEVICE_ID_KEY);
+
+        if ( StringUtils.isBlank(deviceId) ) {
+            return Mono.defer(() -> Mono.error(
+                    new MissingRequestParameterException("'device_id' parameter is required")
+            ));
+        }
+
+        return Mono.just(
+                DisconnectDeviceArgs.withDeviceId(deviceId)
+        );
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/PlayCommandContextResolver.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/PlayCommandContextResolver.java
@@ -1,0 +1,64 @@
+package com.odeyalo.sonata.connect.support.web.resolver;
+
+import com.odeyalo.sonata.connect.dto.PlayResumePlaybackRequest;
+import com.odeyalo.sonata.connect.service.player.PlayCommandContext;
+import jakarta.validation.Valid;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.annotation.AbstractMessageReaderArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+/**
+ * Resolves a {@link PlayCommandContext} from the given {@link ServerWebExchange}
+ */
+@Component
+public final class PlayCommandContextResolver extends AbstractMessageReaderArgumentResolver {
+
+    public PlayCommandContextResolver(final List<HttpMessageReader<?>> readers) {
+        super(readers);
+    }
+
+    @Override
+    public boolean supportsParameter(@NotNull final MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(PlayCommandContext.class);
+    }
+
+    @Override
+    @NotNull
+    public Mono<Object> resolveArgument(@NotNull final MethodParameter parameter,
+                                        @NotNull final BindingContext bindingContext,
+                                        @NotNull final ServerWebExchange exchange) {
+
+        final Parameter bodyTypeParameter = resolveBodyTypeParameter();
+
+        return readBody(MethodParameter.forParameter(bodyTypeParameter), parameter, true, bindingContext, exchange)
+                .cast(PlayResumePlaybackRequest.class)
+                .map(PlayResumePlaybackRequest::getContextUri)
+                .map(PlayCommandContext::from);
+    }
+
+    @NotNull
+    private Parameter resolveBodyTypeParameter() {
+        //noinspection DataFlowIssue never be null because we always have method in this class
+        return ReflectionUtils
+                .findMethod(this.getClass(), "methodParameterDescriptorSupport", PlayResumePlaybackRequest.class)
+                .getParameters()[0];
+    }
+    /**
+     * Support method to resolve {@link Parameter} to set in {@link MethodParameter}
+     * DO NOT DELETE IT IN ANY CASE, ONLY IF YOU FOUND A BETTER SOLUTION
+     *
+     * @param body - body class to read content to
+     */
+    @SuppressWarnings("unused")
+    private void methodParameterDescriptorSupport(@Valid PlayResumePlaybackRequest body) {
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/SwitchDeviceCommandArgsResolver.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/SwitchDeviceCommandArgsResolver.java
@@ -1,0 +1,34 @@
+package com.odeyalo.sonata.connect.support.web.resolver;
+
+import com.odeyalo.sonata.connect.service.player.SwitchDeviceCommandArgs;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * Custom resolver to resolve the {@link SwitchDeviceCommandArgs} from the given {@link ServerWebExchange}.
+ * Any parameter with this type will be resolved by this resolver.
+ */
+@Component
+public final class SwitchDeviceCommandArgsResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(final @NotNull MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(SwitchDeviceCommandArgs.class);
+    }
+
+    @Override
+    @NotNull
+    public Mono<Object> resolveArgument(@NotNull final MethodParameter parameter,
+                                        @NotNull final BindingContext bindingContext,
+                                        @NotNull final ServerWebExchange exchange) {
+        return Mono.just(
+                // We don't support it now, return default value
+                SwitchDeviceCommandArgs.noMatter()
+        );
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/TargetDeactivationDevicesResolver.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/TargetDeactivationDevicesResolver.java
@@ -1,0 +1,29 @@
+package com.odeyalo.sonata.connect.support.web.resolver;
+
+import com.odeyalo.sonata.connect.service.player.TargetDeactivationDevices;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Component
+public final class TargetDeactivationDevicesResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(@NotNull final MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(TargetDeactivationDevices.class);
+    }
+
+    @Override
+    @NotNull
+    public Mono<Object> resolveArgument(@NotNull final MethodParameter parameter,
+                                        @NotNull final BindingContext bindingContext,
+                                        @NotNull final ServerWebExchange exchange) {
+        return Mono.just(
+                TargetDeactivationDevices.empty()
+        );
+    }
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/TransferPlaybackDevicesResolver.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/web/resolver/TransferPlaybackDevicesResolver.java
@@ -1,0 +1,66 @@
+package com.odeyalo.sonata.connect.support.web.resolver;
+
+import com.odeyalo.sonata.connect.dto.DeviceSwitchRequest;
+import com.odeyalo.sonata.connect.service.player.sync.TargetDevices;
+import com.odeyalo.sonata.connect.support.web.annotation.TransferPlaybackTargets;
+import jakarta.validation.Valid;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.web.reactive.BindingContext;
+import org.springframework.web.reactive.result.method.annotation.AbstractMessageReaderArgumentResolver;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+/**
+ * Custom {@link org.springframework.web.reactive.result.method.HandlerMethodArgumentResolver} that used to resolve {@link TargetDevices} from the given {@link ServerWebExchange}.
+ * Only parameters annotated with {@link TransferPlaybackTargets} will be handled.
+ */
+@Component
+public final class TransferPlaybackDevicesResolver extends AbstractMessageReaderArgumentResolver {
+
+    public TransferPlaybackDevicesResolver(final List<HttpMessageReader<?>> readers) {
+        super(readers);
+    }
+
+    @Override
+    public boolean supportsParameter(final MethodParameter parameter) {
+        return parameter.getParameterType().isAssignableFrom(TargetDevices.class) &&
+                parameter.hasParameterAnnotation(TransferPlaybackTargets.class);
+    }
+
+    @Override
+    @NotNull
+    public Mono<Object> resolveArgument(@NotNull final MethodParameter parameter,
+                                        @NotNull final BindingContext bindingContext,
+                                        @NotNull final ServerWebExchange exchange) {
+
+        final Parameter bodyTypeParameter = resolveBodyTypeParameter();
+
+        return readBody(MethodParameter.forParameter(bodyTypeParameter), parameter, true, bindingContext, exchange)
+                .cast(DeviceSwitchRequest.class)
+                .map(DeviceSwitchRequest::getDeviceIds)
+                .map(TargetDevices::fromDeviceIds);
+    }
+
+    private Parameter resolveBodyTypeParameter() {
+        //noinspection DataFlowIssue never be null because we always have method in this class
+        return ReflectionUtils
+                .findMethod(this.getClass(), "methodParameterDescriptorSupport", DeviceSwitchRequest.class)
+                .getParameters()[0];
+    }
+    /**
+     * Support method to resolve {@link Parameter} to set in {@link MethodParameter}
+     * DO NOT DELETE IT IN ANY CASE, ONLY IF YOU FOUND A BETTER SOLUTION
+     *
+     * @param body - body class to read content to
+     */
+    @SuppressWarnings("unused")
+    private void methodParameterDescriptorSupport(@Valid DeviceSwitchRequest body) {
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/controller/ChangeShuffleStateEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/ChangeShuffleStateEndpointTest.java
@@ -31,7 +31,7 @@ import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerPro
         repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
         ids = "com.odeyalo.sonata:authorization:+")
 @TestPropertySource(locations = "classpath:application-test.properties")
-public class UpdatePlayerStatePlayerControllerTest {
+public class ChangeShuffleStateEndpointTest {
 
     @Autowired
     WebTestClient testClient;

--- a/src/test/java/com/odeyalo/sonata/connect/controller/ConnectDeviceEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/ConnectDeviceEndpointTest.java
@@ -28,7 +28,7 @@ import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerPro
         repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
         ids = "com.odeyalo.sonata:authorization:+")
 @TestPropertySource(locations = "classpath:application-test.properties")
-public class ConnectDevicePlayerStateControllerTest {
+public class ConnectDeviceEndpointTest {
 
     @Autowired
     WebTestClient webTestClient;
@@ -38,6 +38,7 @@ public class ConnectDevicePlayerStateControllerTest {
 
     final String VALID_ACCESS_TOKEN = "Bearer mikunakanoisthebestgirl";
     final String VALID_USER_ID = "1";
+    static final String TESTABLE_ENDPOINT_URI = "/player/devices";
 
     @BeforeAll
     void setup() {
@@ -355,8 +356,8 @@ public class ConnectDevicePlayerStateControllerTest {
 
     @NotNull
     private WebTestClient.ResponseSpec sendRequestWithPlainJson(String json) {
-        return webTestClient.put()
-                .uri("/player/device/connect")
+        return webTestClient.post()
+                .uri(TESTABLE_ENDPOINT_URI)
                 .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(json)
@@ -374,8 +375,8 @@ public class ConnectDevicePlayerStateControllerTest {
 
     @NotNull
     private WebTestClient.ResponseSpec sendRequest(ConnectDeviceRequest connectDeviceRequest) {
-        return webTestClient.put()
-                .uri("/player/device/connect")
+        return webTestClient.post()
+                .uri(TESTABLE_ENDPOINT_URI)
                 .header(HttpHeaders.AUTHORIZATION, VALID_ACCESS_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(connectDeviceRequest)

--- a/src/test/java/com/odeyalo/sonata/connect/controller/CurrentlyPlayingEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/CurrentlyPlayingEndpointTest.java
@@ -33,7 +33,7 @@ import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerPro
         repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
         ids = "com.odeyalo.sonata:authorization:+")
 @ActiveProfiles("test")
-public class CurrentlyPlayingPlayerStateControllerTest {
+public class CurrentlyPlayingEndpointTest {
 
     @Autowired
     WebTestClient webTestClient;

--- a/src/test/java/com/odeyalo/sonata/connect/controller/DisconnectDeviceEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/DisconnectDeviceEndpointTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.contract.stubrunner.spring.AutoConfigureStubRunner;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -20,19 +19,16 @@ import testing.asserts.AvailableDevicesResponseDtoAssert;
 import testing.faker.ConnectDeviceRequestFaker;
 import testing.shared.SonataTestHttpOperations;
 import testing.spring.autoconfigure.AutoConfigureSonataHttpClient;
-
-import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerProperties.StubsMode.REMOTE;
+import testing.spring.stubs.AutoConfigureSonataStubs;
 
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @AutoConfigureWebTestClient
 @AutoConfigureSonataHttpClient
-@AutoConfigureStubRunner(stubsMode = REMOTE,
-        repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
-        ids = "com.odeyalo.sonata:authorization:+")
+@AutoConfigureSonataStubs
 @ActiveProfiles("test")
 public final class DisconnectDeviceEndpointTest {
-    public static final String DISCONNECT_DEVICE_ENDPOINT = "/player/device";
+    public static final String DISCONNECT_DEVICE_ENDPOINT = "/player/devices";
 
     @Autowired
     WebTestClient webTestClient;

--- a/src/test/java/com/odeyalo/sonata/connect/controller/FetchAvailableDevicesEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/FetchAvailableDevicesEndpointTest.java
@@ -27,7 +27,7 @@ import static org.springframework.cloud.contract.stubrunner.spring.StubRunnerPro
         repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
         ids = "com.odeyalo.sonata:authorization:+")
 @TestPropertySource(locations = "classpath:application-test.properties")
-public class AvailableDevicesPlayerStateControllerTest {
+public class FetchAvailableDevicesEndpointTest {
 
     @Autowired
     WebTestClient webTestClient;

--- a/src/test/java/com/odeyalo/sonata/connect/controller/PlayResumePlaybackEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/PlayResumePlaybackEndpointTest.java
@@ -196,7 +196,7 @@ public class PlayResumePlaybackEndpointTest {
 
     @Nested
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    class EmptyDeviceListTestsEntity {
+    class EmptyDeviceListTest {
 
         @Test
         void shouldReturnBadRequest() {

--- a/src/test/java/com/odeyalo/sonata/connect/controller/PlayResumePlaybackEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/PlayResumePlaybackEndpointTest.java
@@ -123,6 +123,7 @@ public class PlayResumePlaybackEndpointTest {
 
     @Test
     void shouldUpdateCurrentlyPlayingType() {
+        Hooks.onOperatorDebug();
         connectDevice();
 
         final WebTestClient.ResponseSpec ignored = sendResumeEndpointRequest(

--- a/src/test/java/com/odeyalo/sonata/connect/controller/SwitchDevicesEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/SwitchDevicesEndpointTest.java
@@ -32,7 +32,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
         repositoryRoot = "git://https://github.com/Project-Sonata/Sonata-Contracts.git",
         ids = "com.odeyalo.sonata:authorization:+")
 @ActiveProfiles("test")
-public class DeviceEntitySwitchPlayerControllerTests {
+public class SwitchDevicesEndpointTest {
     public static final String DEVICE_SWITCH_ENDPOINT = "/player/device/switch";
 
     @Autowired

--- a/src/test/java/com/odeyalo/sonata/connect/controller/SwitchDevicesEndpointTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/controller/SwitchDevicesEndpointTest.java
@@ -33,7 +33,7 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
         ids = "com.odeyalo.sonata:authorization:+")
 @ActiveProfiles("test")
 public class SwitchDevicesEndpointTest {
-    public static final String DEVICE_SWITCH_ENDPOINT = "/player/device/switch";
+    public static final String DEVICE_SWITCH_ENDPOINT = "/player/devices";
 
     @Autowired
     WebTestClient webTestClient;

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/EventPublisherPlayerOperationsDecoratorTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/EventPublisherPlayerOperationsDecoratorTest.java
@@ -1,5 +1,6 @@
 package com.odeyalo.sonata.connect.service.player;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.connect.entity.DeviceEntity;
 import com.odeyalo.sonata.connect.entity.DevicesEntity;
 import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
@@ -37,7 +38,9 @@ import static org.mockito.Mockito.*;
 class EventPublisherPlayerOperationsDecoratorTest {
     public static final User USER = User.of("odeyalo");
     public static final String EXISTING_TRACK_CONTEXT_URI = "sonata:track:miku";
-    public static final PlayCommandContext VALID_PLAY_COMMAND_CONTEXT = PlayCommandContext.of(EXISTING_TRACK_CONTEXT_URI);
+    public static final PlayCommandContext VALID_PLAY_COMMAND_CONTEXT = PlayCommandContext.of(
+            ContextUri.fromString(EXISTING_TRACK_CONTEXT_URI)
+    );
     public static final TrackItem TRACK_1 = TrackItemFaker.create().withContextUri(EXISTING_TRACK_CONTEXT_URI).get();
 
 

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/PlayResumeCommandTests.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/PlayResumeCommandTests.java
@@ -1,8 +1,7 @@
 package com.odeyalo.sonata.connect.service.player;
 
+import com.odeyalo.sonata.common.context.ContextUri;
 import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
-import com.odeyalo.sonata.connect.exception.ReasonCodeAware;
-import com.odeyalo.sonata.connect.exception.ReasonCodeAwareMalformedContextUriException;
 import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.model.TrackItem;
 import org.junit.jupiter.api.Test;
@@ -15,8 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static testing.factory.DefaultPlayerOperationsTestableBuilder.testableBuilder;
 
 class PlayResumeCommandTests extends DefaultPlayerOperationsTest {
-    static final String INVALID_CONTEXT_URI = "sonata:invalid:cassie";
-    static final String EXISTING_PLAYABLE_ITEM_CONTEXT = "sonata:track:cassie";
+    static final ContextUri EXISTING_PLAYABLE_ITEM_CONTEXT = ContextUri.forTrack("cassie");
     static final TrackItem TRACK_1 = TrackItemFaker.create().withId("cassie").get();
 
     @Test
@@ -48,40 +46,5 @@ class PlayResumeCommandTests extends DefaultPlayerOperationsTest {
                 .as(StepVerifier::create)
                 .assertNext(it -> assertThat(it.getItemType()).isEqualTo(TRACK))
                 .verifyComplete();
-    }
-
-    @Test
-    void shouldThrowExceptionIfContextUriIsInvalid() {
-        final PlayerStateEntity playerState = existingPlayerState();
-
-        final DefaultPlayerOperations testable = testableBuilder()
-                .withState(playerState)
-                .build();
-
-        testable.playOrResume(EXISTING_USER, PlayCommandContext.of(INVALID_CONTEXT_URI), CURRENT_DEVICE)
-                .as(StepVerifier::create)
-                .expectError(ReasonCodeAwareMalformedContextUriException.class)
-                .verify();
-    }
-
-    @Test
-    void shouldContainReasonCodeIfContextUriIsInvalid() {
-        final PlayerStateEntity playerState = existingPlayerState();
-
-        final DefaultPlayerOperations testable = testableBuilder()
-                .withState(playerState)
-                .build();
-
-        testable.playOrResume(EXISTING_USER, PlayCommandContext.of(INVALID_CONTEXT_URI), CURRENT_DEVICE)
-                .as(StepVerifier::create)
-                .expectErrorMatches(err -> verifyReasonCode(err, "malformed_context_uri"))
-                .verify();
-    }
-
-    private static boolean verifyReasonCode(Throwable err, String expected) {
-        if ( err instanceof ReasonCodeAware reasonCodeAware ) {
-            return reasonCodeAware.getReasonCode().equals(expected);
-        }
-        return false;
     }
 }

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/PlayResumeCommandTests.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/PlayResumeCommandTests.java
@@ -1,12 +1,17 @@
 package com.odeyalo.sonata.connect.service.player;
 
 import com.odeyalo.sonata.common.context.ContextUri;
+import com.odeyalo.sonata.connect.entity.DevicesEntity;
 import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
-import com.odeyalo.sonata.connect.model.CurrentPlayerState;
+import com.odeyalo.sonata.connect.entity.TrackItemEntity;
+import com.odeyalo.sonata.connect.exception.NoActiveDeviceException;
+import com.odeyalo.sonata.connect.exception.PlayableItemNotFoundException;
+import com.odeyalo.sonata.connect.model.PlayingType;
 import com.odeyalo.sonata.connect.model.TrackItem;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import testing.faker.PlayableItemFaker.TrackItemFaker;
+import testing.faker.TrackItemEntityFaker;
 
 import static com.odeyalo.sonata.connect.model.PlayableItemType.TRACK;
 import static com.odeyalo.sonata.connect.service.player.BasicPlayerOperations.CURRENT_DEVICE;
@@ -14,37 +19,124 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static testing.factory.DefaultPlayerOperationsTestableBuilder.testableBuilder;
 
 class PlayResumeCommandTests extends DefaultPlayerOperationsTest {
-    static final ContextUri EXISTING_PLAYABLE_ITEM_CONTEXT = ContextUri.forTrack("cassie");
+    static final ContextUri TRACK_1_CONTEXT_URI = ContextUri.forTrack("cassie");
+    static final ContextUri TRACK_2_CONTEXT_URI = ContextUri.forTrack("miku13");
+
     static final TrackItem TRACK_1 = TrackItemFaker.create().withId("cassie").get();
+    static final TrackItem TRACK_2 = TrackItemFaker.create().withId("miku13").get();
 
     @Test
-    void shouldUpdatePlayerStateWithCorrectPlayableItemId() {
-        final PlayerStateEntity playerState = existingPlayerState();
+    void shouldResumePlaybackIfContextUriIsEqualToProvided() {
+        final TrackItemEntity playingItem = TrackItemEntityFaker.create()
+                .withId("cassie")
+                .get();
 
-        final DefaultPlayerOperations testable = testableBuilder().withState(playerState)
-                .withPlayableItems(TRACK_1)
-                .build();
-
-        testable.playOrResume(DefaultPlayerOperationsTest.EXISTING_USER, PlayCommandContext.of(EXISTING_PLAYABLE_ITEM_CONTEXT), CURRENT_DEVICE)
-                .mapNotNull(CurrentPlayerState::getPlayableItem)
-                .as(StepVerifier::create)
-                .assertNext(it -> assertThat(it.getId()).isEqualTo("cassie"))
-                .verifyComplete();
-    }
-
-    @Test
-    void shouldUpdatePlayerStateWithCorrectPlayableItemType() {
-        final PlayerStateEntity playerState = existingPlayerState();
+        final PlayerStateEntity playerState = existingPlayerState()
+                .setPlaying(false)
+                .setCurrentlyPlayingItem(playingItem)
+                .setPlayingType(PlayingType.TRACK);
 
         final DefaultPlayerOperations testable = testableBuilder()
                 .withState(playerState)
                 .withPlayableItems(TRACK_1)
                 .build();
 
-        testable.playOrResume(DefaultPlayerOperationsTest.EXISTING_USER, PlayCommandContext.of(EXISTING_PLAYABLE_ITEM_CONTEXT), CURRENT_DEVICE)
-                .mapNotNull(CurrentPlayerState::getPlayableItem)
+        testable.playOrResume(EXISTING_USER, PlayCommandContext.of(TRACK_1_CONTEXT_URI), CURRENT_DEVICE)
                 .as(StepVerifier::create)
-                .assertNext(it -> assertThat(it.getItemType()).isEqualTo(TRACK))
+                .assertNext(state -> {
+                    assertThat(state.isPlaying()).isTrue();
+                    assertThat(state.getPlayableItem()).isNotNull();
+                    assertThat(state.getPlayableItem().getId()).isEqualTo("cassie");
+                    assertThat(state.getPlayableItem().getContextUri()).isEqualTo(TRACK_1_CONTEXT_URI);
+                    assertThat(state.getPlayableItem().getItemType()).isEqualTo(TRACK);
+                })
                 .verifyComplete();
     }
+
+    @Test
+    void shouldResumePlaybackIfProvidedContextUriIsMissing() {
+        final TrackItemEntity playingItem = TrackItemEntityFaker.create()
+                .withId("cassie")
+                .get();
+
+        final PlayerStateEntity playerState = existingPlayerState()
+                .setPlaying(false)
+                .setCurrentlyPlayingItem(playingItem)
+                .setPlayingType(PlayingType.TRACK);
+
+        final DefaultPlayerOperations testable = testableBuilder()
+                .withState(playerState)
+                .withPlayableItems(TRACK_1)
+                .build();
+
+        testable.playOrResume(EXISTING_USER, PlayCommandContext.resumePlayback(), CURRENT_DEVICE)
+                .as(StepVerifier::create)
+                .assertNext(state -> {
+                    assertThat(state.isPlaying()).isTrue();
+                    assertThat(state.getPlayableItem()).isNotNull();
+                    assertThat(state.getPlayableItem().getId()).isEqualTo("cassie");
+                    assertThat(state.getPlayableItem().getContextUri()).isEqualTo(TRACK_1_CONTEXT_URI);
+                    assertThat(state.getPlayableItem().getItemType()).isEqualTo(TRACK);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnErrorIfPlayableItemByContextUriDoesNotExist() {
+        final PlayerStateEntity playerState = existingPlayerState();
+
+        final DefaultPlayerOperations testable = testableBuilder()
+                .withState(playerState)
+                .build();
+
+        testable.playOrResume(EXISTING_USER, PlayCommandContext.of(ContextUri.forTrack("not_exist") ), CURRENT_DEVICE)
+                .as(StepVerifier::create)
+                .expectError(PlayableItemNotFoundException.class)
+                .verify();
+    }
+
+    @Test
+    void shouldStartPlayingNewItemIfOtherItemWasProvided() {
+        final TrackItemEntity playingItem = TrackItemEntityFaker.create()
+                .withId("cassie")
+                .get();
+
+        final PlayerStateEntity playerState = existingPlayerState()
+                .setPlaying(false)
+                .setCurrentlyPlayingItem(playingItem)
+                .setPlayingType(PlayingType.TRACK);
+
+        final DefaultPlayerOperations testable = testableBuilder()
+                .withState(playerState)
+                .withPlayableItems(TRACK_1, TRACK_2)
+                .build();
+
+        testable.playOrResume(EXISTING_USER, PlayCommandContext.of(TRACK_2_CONTEXT_URI), CURRENT_DEVICE)
+                .as(StepVerifier::create)
+                .assertNext(state -> {
+                    assertThat(state.isPlaying()).isTrue();
+                    assertThat(state.getPlayableItem()).isNotNull();
+                    assertThat(state.getPlayableItem().getId()).isEqualTo("miku13");
+                    assertThat(state.getPlayableItem().getContextUri()).isEqualTo(TRACK_2_CONTEXT_URI);
+                    assertThat(state.getPlayableItem().getItemType()).isEqualTo(TRACK);
+                })
+                .verifyComplete();
+    }
+
+    @Test
+    void shouldReturnErrorIfNoDevicesAreConnected() {
+        final PlayerStateEntity playerState = existingPlayerState()
+                .setDevicesEntity(DevicesEntity.empty());
+
+        final DefaultPlayerOperations testable = testableBuilder()
+                .withState(playerState)
+                .withPlayableItems(TRACK_1)
+                .build();
+
+        testable.playOrResume(EXISTING_USER, PlayCommandContext.from(TRACK_1_CONTEXT_URI), CURRENT_DEVICE)
+                .as(StepVerifier::create)
+                .expectError(NoActiveDeviceException.class)
+                .verify();
+    }
+
 }

--- a/src/test/java/testing/PlayerStatePersistentOperationsTestAdapter.java
+++ b/src/test/java/testing/PlayerStatePersistentOperationsTestAdapter.java
@@ -3,6 +3,7 @@ package testing;
 import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
 import com.odeyalo.sonata.connect.repository.PlayerStatePersistentOperations;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Disabled // Ignore the tests from the base class, tests will execute for child classes
 public class PlayerStatePersistentOperationsTestAdapter {
 
     final PlayerStatePersistentOperations testTarget;

--- a/src/test/java/testing/factory/DefaultPlayerOperationsTestableBuilder.java
+++ b/src/test/java/testing/factory/DefaultPlayerOperationsTestableBuilder.java
@@ -35,9 +35,11 @@ public final class DefaultPlayerOperationsTestableBuilder {
     private final CurrentPlayerState2CurrentlyPlayingPlayerStateConverter playerStateConverter = new Converters().currentPlayerStateConverter();
 
     private final PauseCommandHandlerDelegate pauseCommandHandlerDelegate =
-            new PlayerStateUpdatePauseCommandHandlerDelegate(playerStateRepository,
+            new PlayerStateUpdatePauseCommandHandlerDelegate(
                     new HardCodedPauseCommandPreExecutingIntegrityValidator(),
-                    playerStateConverterSupport);
+                    new PlayerStateService(playerStateRepository, playerStateConverterSupport, new DefaultPlayerStateEntityFactory(
+                            new DeviceEntity.Factory(), new TrackItemEntity.Factory()
+                    )));
 
     public static DefaultPlayerOperationsTestableBuilder testableBuilder() {
         return new DefaultPlayerOperationsTestableBuilder();

--- a/src/test/java/testing/factory/DefaultPlayerOperationsTestableBuilder.java
+++ b/src/test/java/testing/factory/DefaultPlayerOperationsTestableBuilder.java
@@ -90,11 +90,11 @@ public final class DefaultPlayerOperationsTestableBuilder {
 
         public PlayCommandHandlerDelegate build() {
             return new PlayerStateUpdatePlayCommandHandlerDelegate(
-                    playerStateRepository,
-                    testableBuilder().playerStateConverterSupport,
                     itemLoader,
-                    new HardcodedPlayCommandPreExecutingIntegrityValidator()
-            );
+                    new HardcodedPlayCommandPreExecutingIntegrityValidator(),
+                    new PlayerStateService(playerStateRepository, testableBuilder().playerStateConverterSupport, new DefaultPlayerStateEntityFactory(
+                            new DeviceEntity.Factory(), new TrackItemEntity.Factory()
+                    )));
         }
     }
 }

--- a/src/test/java/testing/faker/PlayerStateFaker.java
+++ b/src/test/java/testing/faker/PlayerStateFaker.java
@@ -2,10 +2,7 @@ package testing.faker;
 
 import com.github.javafaker.Faker;
 import com.odeyalo.sonata.connect.entity.*;
-import com.odeyalo.sonata.connect.model.PlayingType;
-import com.odeyalo.sonata.connect.model.RepeatState;
-import com.odeyalo.sonata.connect.model.ShuffleMode;
-import com.odeyalo.sonata.connect.model.User;
+import com.odeyalo.sonata.connect.model.*;
 import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.experimental.Accessors;
@@ -34,6 +31,7 @@ public class PlayerStateFaker {
                 .shuffleState(faker.options().option(ShuffleMode.class))
                 .progressMs(faker.random().nextLong(1000000))
                 .playingType(faker.options().option(PlayingType.class))
+                .volume(Volume.fromInt(faker.random().nextInt(0, 100)))
                 .user(UserEntityFaker.create().get());
 
         if ( numberOfDevices <= 0 ) {

--- a/src/test/java/testing/faker/TrackItemEntityFaker.java
+++ b/src/test/java/testing/faker/TrackItemEntityFaker.java
@@ -34,7 +34,15 @@ public final class TrackItemEntityFaker {
         return new TrackItemEntityFaker();
     }
 
+
+
     public TrackItemEntity get() {
         return builder.build();
+    }
+
+    public TrackItemEntityFaker withId(final String id) {
+        builder.id(id)
+                .contextUri(ContextUri.forTrack(id));
+        return this;
     }
 }

--- a/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
+++ b/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
@@ -67,7 +67,7 @@ public class WebTestClientSonataTestHttpOperations implements SonataTestHttpOper
     @Override
     public void switchDevices(String authorizationHeaderValue, DeviceSwitchRequest body) {
         webTestClient.put()
-                .uri("/player/device/switch")
+                .uri("/player/devices")
                 .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
                 .bodyValue(body);
     }

--- a/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
+++ b/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
@@ -35,8 +35,8 @@ public class WebTestClientSonataTestHttpOperations implements SonataTestHttpOper
 
     @Override
     public void connectDevice(String authorizationHeaderValue, ConnectDeviceRequest body) {
-        webTestClient.put()
-                .uri("/player/device/connect")
+        webTestClient.post()
+                .uri("/player/devices")
                 .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(body)


### PR DESCRIPTION
Refactored API by changing:
- changed  PUT /plaver/device/connect - to POST /player/devices
- changed PUT /player/device/switch to PUT /player/device

Moved creation of Command classes from controller to HandlerMethodArgumentResolver(s). 

Moved methods that used to manipulate with player from entity to domain model(CurrentPlayerState).