### PR TITLE
[FEATURE] Now play command endpoint does not require body

### DIFF
--- a/sonata-connect-run.test.sh
+++ b/sonata-connect-run.test.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose -f docker-compose.test.yml up --abort-on-container-exit
+docker compose -f docker-compose.test.yml up --abort-on-container-exit

--- a/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
+++ b/src/main/java/com/odeyalo/sonata/connect/service/player/handler/PlayerStateUpdatePlayCommandHandlerDelegate.java
@@ -42,14 +42,14 @@ public class PlayerStateUpdatePlayCommandHandlerDelegate implements PlayCommandH
     }
 
     @NotNull
-    private Mono<CurrentPlayerState> executeCommand(@NotNull final PlayCommandContext context,
+    private Mono<CurrentPlayerState> executeCommand(@NotNull final PlayCommandContext playback,
                                                     @NotNull final CurrentPlayerState state) {
 
-        if ( context.getContextUri() == null ) {
+        if ( playback.shouldBeResumed() ) {
             return resumePlayback(state);
         }
 
-        return playableItemLoader.loadPlayableItem(context.getContextUri())
+        return playableItemLoader.loadPlayableItem(playback.getContextUri())
                 .switchIfEmpty(Mono.defer(() -> Mono.error(PlayableItemNotFoundException.defaultException())))
                 .flatMap(item -> play(state, item));
     }

--- a/src/test/java/testing/shared/SonataTestHttpOperations.java
+++ b/src/test/java/testing/shared/SonataTestHttpOperations.java
@@ -18,6 +18,8 @@ public interface SonataTestHttpOperations {
 
     void playOrResumePlayback(String authorizationHeaderValue, PlayResumePlaybackRequest body);
 
+    void pause(String validAccessToken);
+
     void changeShuffle(String authorizationHeaderValue, boolean shuffleMode);
 
     void switchDevices(String authorizationHeaderValue, DeviceSwitchRequest body);

--- a/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
+++ b/src/test/java/testing/shared/WebTestClientSonataTestHttpOperations.java
@@ -54,6 +54,15 @@ public class WebTestClientSonataTestHttpOperations implements SonataTestHttpOper
     }
 
     @Override
+    public void pause(String authorizationHeaderValue) {
+        webTestClient.put()
+                .uri("/player/pause")
+                .header(HttpHeaders.AUTHORIZATION, authorizationHeaderValue)
+                .exchange()
+                .expectStatus().isNoContent();
+    }
+
+    @Override
     public void changeShuffle(String authorizationHeaderValue, boolean shuffleMode) {
         webTestClient.put()
                 .uri(builder -> {


### PR DESCRIPTION
Implementation of https://github.com/Project-Sonata/Sonata-Connect/issues/69

Now play command does not require body, if body missing, then we assume that user want to resume the playback  