### PR TITLE
[FEATURE] Fixed bug when progress was calculated wrongly

### DIFF
--- a/src/main/java/com/odeyalo/sonata/connect/entity/PlayerStateEntity.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/PlayerStateEntity.java
@@ -19,10 +19,12 @@ import org.jetbrains.annotations.Nullable;
 public class PlayerStateEntity {
     Long id;
     boolean playing;
-    @Nullable
-    RepeatState repeatState;
     @NotNull
-    ShuffleMode shuffleState;
+    @Builder.Default
+    RepeatState repeatState = RepeatState.OFF;
+    @NotNull
+    @Builder.Default
+    ShuffleMode shuffleState = ShuffleMode.OFF;
     @Builder.Default
     Long progressMs = 0L;
     @Nullable
@@ -36,21 +38,15 @@ public class PlayerStateEntity {
     PlayableItemEntity currentlyPlayingItem;
     @NotNull
     Volume volume;
-    @Getter(value = AccessLevel.PRIVATE)
-    @Setter(value = AccessLevel.PRIVATE)
     long playStartTime = 0;
-    @Getter(value = AccessLevel.PRIVATE)
-    @Setter(value = AccessLevel.PRIVATE)
     long lastPauseTime = 0;
-
-    public static final boolean SHUFFLE_ENABLED = true;
-    public static final boolean SHUFFLE_DISABLED = false;
 
     @NotNull
     public ShuffleMode getShuffleState() {
         return shuffleState;
     }
 
+    @Nullable
     public PlayingType getCurrentlyPlayingType() {
         return playingType;
     }
@@ -60,6 +56,7 @@ public class PlayerStateEntity {
         return currentlyPlayingItem;
     }
 
+    @NotNull
     public DevicesEntity getDevices() {
         return devicesEntity;
     }

--- a/src/main/java/com/odeyalo/sonata/connect/entity/factory/DefaultPlayerStateEntityFactory.java
+++ b/src/main/java/com/odeyalo/sonata/connect/entity/factory/DefaultPlayerStateEntityFactory.java
@@ -31,6 +31,7 @@ public final class DefaultPlayerStateEntityFactory implements PlayerStateEntityF
                 .shuffleState(state.getShuffleState())
                 .user(UserEntity.builder().id(state.getUser().getId()).build())
                 .devicesEntity(DevicesEntity.fromCollection(devices))
+                .progressMs(state.getProgressMs())
                 .lastPauseTime(state.getLastPauseTime())
                 .playStartTime(state.getPlayStartTime());
 

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -2,6 +2,8 @@ package com.odeyalo.sonata.connect.model;
 
 import com.odeyalo.sonata.connect.service.player.TargetDeactivationDevice;
 import com.odeyalo.sonata.connect.service.player.TargetDevice;
+import com.odeyalo.sonata.connect.support.time.Clock;
+import com.odeyalo.sonata.connect.support.time.JavaClock;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Value;
@@ -45,6 +47,9 @@ public class CurrentPlayerState {
     long lastPauseTime = 0;
     @Builder.Default
     long playStartTime = 0;
+    @NotNull
+    @Builder.Default
+    Clock clock = JavaClock.instance();
 
     @NotNull
     public static CurrentPlayerState emptyFor(@NotNull final User user) {
@@ -52,6 +57,11 @@ public class CurrentPlayerState {
                 .id(new Random().nextLong(0, Long.MAX_VALUE))
                 .user(user)
                 .build();
+    }
+
+    @NotNull
+    public CurrentPlayerState useClock(@NotNull final Clock clock) {
+        return withClock(clock);
     }
 
     @NotNull
@@ -102,9 +112,14 @@ public class CurrentPlayerState {
             return -1L;
         }
 
+        if (playableItem.getDuration().asMilliseconds() <= (progressMs + calculateProgress())) {
+            return playableItem.getDuration().asMilliseconds();
+        }
+
         if ( isPlaying() ) {
             return progressMs + calculateProgress();
         }
+
         return progressMs;
     }
 
@@ -139,7 +154,7 @@ public class CurrentPlayerState {
                 .playing(true)
                 .playableItem(item)
                 .playingType(PlayingType.valueOf(item.getItemType().name()))
-                .playStartTime(System.currentTimeMillis())
+                .playStartTime(clock.currentTimeMillis())
                 .progressMs(0L)
                 .build();
     }
@@ -148,7 +163,7 @@ public class CurrentPlayerState {
     public CurrentPlayerState resumePlayback() {
         return this.toBuilder()
                 .playing(true)
-                .playStartTime(System.currentTimeMillis())
+                .playStartTime(clock.currentTimeMillis())
                 .build();
     }
 
@@ -157,7 +172,7 @@ public class CurrentPlayerState {
         if ( isPlaying() ) {
             return this.toBuilder()
                     .playing(false)
-                    .lastPauseTime(System.currentTimeMillis())
+                    .lastPauseTime(clock.currentTimeMillis())
                     .progressMs(progressMs + calculateProgress())
                     .build();
         }
@@ -167,7 +182,7 @@ public class CurrentPlayerState {
 
     private long calculateProgress() {
         if ( isPlaying() ) {
-            return System.currentTimeMillis() - playStartTime;
+            return clock.currentTimeMillis() - playStartTime;
         } else {
             return lastPauseTime - playStartTime;
         }

--- a/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/CurrentPlayerState.java
@@ -112,12 +112,14 @@ public class CurrentPlayerState {
             return -1L;
         }
 
-        if (playableItem.getDuration().asMilliseconds() <= (progressMs + calculateProgress())) {
+        final long currentProgress = getCurrentProgressMs();
+
+        if ( playableItem.getDuration().isExceeded(currentProgress) ) {
             return playableItem.getDuration().asMilliseconds();
         }
 
         if ( isPlaying() ) {
-            return progressMs + calculateProgress();
+            return currentProgress;
         }
 
         return progressMs;
@@ -173,14 +175,18 @@ public class CurrentPlayerState {
             return this.toBuilder()
                     .playing(false)
                     .lastPauseTime(clock.currentTimeMillis())
-                    .progressMs(progressMs + calculateProgress())
+                    .progressMs(getCurrentProgressMs())
                     .build();
         }
 
         return this;
     }
 
-    private long calculateProgress() {
+    private long getCurrentProgressMs() {
+        return progressMs + computeElapsedTime();
+    }
+
+    private long computeElapsedTime() {
         if ( isPlaying() ) {
             return clock.currentTimeMillis() - playStartTime;
         } else {

--- a/src/main/java/com/odeyalo/sonata/connect/model/PlayableItem.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/PlayableItem.java
@@ -14,7 +14,9 @@ public interface PlayableItem {
     @NotNull
     PlayableItemType getItemType();
 
-
     @NotNull
     ContextUri getContextUri();
+
+    @NotNull
+    PlayableItemDuration getDuration();
 }

--- a/src/main/java/com/odeyalo/sonata/connect/model/PlayableItemDuration.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/PlayableItemDuration.java
@@ -42,4 +42,14 @@ public class PlayableItemDuration {
     public long asSeconds() {
         return durationMs / 1000;
     }
+
+    /**
+     * Check if the provided millis exceed the item duration
+     * @param millisToCompare - millis to compare with item duration
+     * @return {@code true} if provided millis exceed the playable item duration
+     * {@code false} otherwise
+     */
+    public boolean isExceeded(final long millisToCompare) {
+        return asMilliseconds() < millisToCompare;
+    }
 }

--- a/src/main/java/com/odeyalo/sonata/connect/model/PlayableItemDuration.java
+++ b/src/main/java/com/odeyalo/sonata/connect/model/PlayableItemDuration.java
@@ -3,7 +3,10 @@ package com.odeyalo.sonata.connect.model;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.util.Assert;
+
+import java.time.Duration;
 
 /**
  * Represent a duration of the {@link PlayableItem}
@@ -22,8 +25,14 @@ public class PlayableItemDuration {
         return new PlayableItemDuration(durationMs);
     }
 
+    @NotNull
     public static PlayableItemDuration ofSeconds(long durationSec) {
         return ofMilliseconds(durationSec * 1000);
+    }
+
+    @NotNull
+    public static PlayableItemDuration fromJavaDuration(@NotNull final Duration itemDuration) {
+        return ofMilliseconds(itemDuration.toMillis());
     }
 
     public long asMilliseconds() {

--- a/src/main/java/com/odeyalo/sonata/connect/support/time/Clock.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/time/Clock.java
@@ -1,0 +1,17 @@
+package com.odeyalo.sonata.connect.support.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+
+/**
+ * A wrapper around the system clock to allow custom implementations to be used in unit tests where we want to fake or control the clock behavior.
+ */
+public interface Clock {
+
+    @NotNull
+    Instant now();
+
+    long currentTimeMillis();
+
+}

--- a/src/main/java/com/odeyalo/sonata/connect/support/time/JavaClock.java
+++ b/src/main/java/com/odeyalo/sonata/connect/support/time/JavaClock.java
@@ -1,0 +1,27 @@
+package com.odeyalo.sonata.connect.support.time;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+
+public final class JavaClock implements Clock {
+    private static final JavaClock INSTANCE = new JavaClock();
+
+    private JavaClock() {}
+
+    @NotNull
+    public static JavaClock instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    @NotNull
+    public Instant now() {
+        return Instant.now();
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return now().toEpochMilli();
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/model/CurrentPlayerStateProgressCalculationTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/model/CurrentPlayerStateProgressCalculationTest.java
@@ -1,0 +1,149 @@
+package com.odeyalo.sonata.connect.model;
+
+import org.junit.jupiter.api.Test;
+import testing.faker.PlayableItemFaker;
+import testing.time.TestingClock;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CurrentPlayerStateProgressCalculationTest {
+    static final User USER = User.of("odeyalooo");
+
+    @Test
+    void shouldReturnDefaultValueIfNothingIsPlaying() {
+        final CurrentPlayerState testable = CurrentPlayerState.emptyFor(USER)
+                .withPlayableItem(null);
+
+        assertThat(testable.getProgressMs()).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldNotReturnDefaultValueIfSomethingIsPlaying() {
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER);
+
+        final CurrentPlayerState updatedState = initialState.play(PlayableItemFaker.create().get());
+
+        assertThat(updatedState.getProgressMs()).isNotEqualTo(-1L);
+    }
+
+    @Test
+    void shouldReturnTheSameProgressIfPlaybackIsPaused() {
+        final CurrentPlayerState testable = CurrentPlayerState.emptyFor(USER)
+                .withPlaying(false)
+                .withProgressMs(2000L)
+                .withPlayableItem(PlayableItemFaker.create().get());
+
+        assertThat(testable.getProgressMs()).isEqualTo(2000L);
+        // check that the progress does not change every time when getProgressMs is called
+        assertThat(testable.getProgressMs()).isEqualTo(2000L);
+        assertThat(testable.getProgressMs()).isEqualTo(2000L);
+    }
+
+    @Test
+    void shouldReturnCurrentProgressForItemThatPlayingNow() {
+
+        final TestingClock clock = new TestingClock(Instant.now());
+
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
+                .useClock(clock);
+
+        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+
+        clock.waitSeconds(2);
+
+        assertThat(testable.getProgressMs()).isEqualTo(2000L);
+
+        clock.waitSeconds(4);
+
+        assertThat(testable.getProgressMs()).isEqualTo(6000L);
+    }
+
+    @Test
+    void shouldReturnProgressMsAfterThePauseCommand() {
+
+        final TestingClock clock = new TestingClock(Instant.now());
+
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
+                .useClock(clock);
+
+        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+
+        clock.waitSeconds(6);
+
+        assertThat(testable.getProgressMs()).isEqualTo(6000L);
+
+        final CurrentPlayerState afterPause = testable.pause();
+
+        clock.waitSeconds(10);
+
+        assertThat(afterPause.getProgressMs()).isEqualTo(6000L);
+    }
+
+    @Test
+    void shouldContinueProgressMsAfterThePointPlaybackWasPaused() {
+
+        final TestingClock clock = new TestingClock(Instant.now());
+
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
+                .useClock(clock);
+
+        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+
+        clock.waitSeconds(6);
+
+        final CurrentPlayerState afterPause = testable.pause();
+
+        clock.waitSeconds(10);
+
+        final CurrentPlayerState afterPlaybackResume = afterPause.resumePlayback();
+
+        clock.waitSeconds(4);
+
+        assertThat(afterPlaybackResume.getProgressMs()).isEqualTo(10_000L);
+    }
+
+    @Test
+    void shouldProperlyCalculateTheProgressIfMillisPassed() {
+
+        final TestingClock clock = new TestingClock(Instant.now());
+
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
+                .useClock(clock);
+
+        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+
+        clock.waitMillis(60);
+
+        assertThat(testable.getProgressMs()).isEqualTo(60L);
+    }
+
+    @Test
+    void test1() {
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER);
+
+        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+
+        assertThat(testable.getProgressMs()).isEqualTo(60L);
+    }
+
+    @Test
+    void shouldReturnEndOfTheProgressIfProgressIsOutOfBoundsOfPlayableItem() {
+        final TestingClock clock = new TestingClock(Instant.now());
+
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
+                .useClock(clock);
+
+        final PlayableItem playableItem = PlayableItemFaker.create()
+                .setDuration(Duration.ofSeconds(230))
+                .get();
+
+        final CurrentPlayerState testable = initialState.play(playableItem);
+
+        clock.waitSeconds(240);
+
+        assertThat(testable.getProgressMs()).isEqualTo(230_000L);
+    }
+}

--- a/src/test/java/com/odeyalo/sonata/connect/model/CurrentPlayerStateProgressCalculationTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/model/CurrentPlayerStateProgressCalculationTest.java
@@ -10,6 +10,10 @@ import java.time.Instant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CurrentPlayerStateProgressCalculationTest {
+    static final PlayableItem SECONDS_30_PLAYABLE_ITEM = PlayableItemFaker.create()
+            .setDuration(Duration.ofSeconds(30))
+            .get();
+
     static final User USER = User.of("odeyalooo");
 
     @Test
@@ -24,7 +28,7 @@ class CurrentPlayerStateProgressCalculationTest {
     void shouldNotReturnDefaultValueIfSomethingIsPlaying() {
         final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER);
 
-        final CurrentPlayerState updatedState = initialState.play(PlayableItemFaker.create().get());
+        final CurrentPlayerState updatedState = initialState.play(SECONDS_30_PLAYABLE_ITEM);
 
         assertThat(updatedState.getProgressMs()).isNotEqualTo(-1L);
     }
@@ -34,7 +38,7 @@ class CurrentPlayerStateProgressCalculationTest {
         final CurrentPlayerState testable = CurrentPlayerState.emptyFor(USER)
                 .withPlaying(false)
                 .withProgressMs(2000L)
-                .withPlayableItem(PlayableItemFaker.create().get());
+                .withPlayableItem(SECONDS_30_PLAYABLE_ITEM);
 
         assertThat(testable.getProgressMs()).isEqualTo(2000L);
         // check that the progress does not change every time when getProgressMs is called
@@ -50,7 +54,7 @@ class CurrentPlayerStateProgressCalculationTest {
         final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
                 .useClock(clock);
 
-        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+        final CurrentPlayerState testable = initialState.play(SECONDS_30_PLAYABLE_ITEM);
 
         clock.waitSeconds(2);
 
@@ -69,7 +73,7 @@ class CurrentPlayerStateProgressCalculationTest {
         final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
                 .useClock(clock);
 
-        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+        final CurrentPlayerState testable = initialState.play(SECONDS_30_PLAYABLE_ITEM);
 
         clock.waitSeconds(6);
 
@@ -90,7 +94,7 @@ class CurrentPlayerStateProgressCalculationTest {
         final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
                 .useClock(clock);
 
-        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+        final CurrentPlayerState testable = initialState.play(SECONDS_30_PLAYABLE_ITEM);
 
         clock.waitSeconds(6);
 
@@ -113,18 +117,9 @@ class CurrentPlayerStateProgressCalculationTest {
         final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
                 .useClock(clock);
 
-        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
+        final CurrentPlayerState testable = initialState.play(SECONDS_30_PLAYABLE_ITEM);
 
         clock.waitMillis(60);
-
-        assertThat(testable.getProgressMs()).isEqualTo(60L);
-    }
-
-    @Test
-    void test1() {
-        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER);
-
-        final CurrentPlayerState testable = initialState.play(PlayableItemFaker.create().get());
 
         assertThat(testable.getProgressMs()).isEqualTo(60L);
     }
@@ -145,5 +140,25 @@ class CurrentPlayerStateProgressCalculationTest {
         clock.waitSeconds(240);
 
         assertThat(testable.getProgressMs()).isEqualTo(230_000L);
+    }
+
+    @Test
+    void shouldReturnEndOfTheProgressIfProgressIsEqualToItemDuration() {
+        final TestingClock clock = new TestingClock(Instant.now());
+
+        final CurrentPlayerState initialState = CurrentPlayerState.emptyFor(USER)
+                .useClock(clock);
+
+        final PlayableItem playableItem = PlayableItemFaker.create()
+                .setDuration(Duration.ofSeconds(230))
+                .get();
+
+        final CurrentPlayerState testable = initialState.play(playableItem);
+
+        clock.waitSeconds(230);
+
+        final CurrentPlayerState pausedPlayback = testable.pause();
+
+        assertThat(pausedPlayback.getProgressMs()).isEqualTo(230_000L);
     }
 }

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/ChangeShuffleStateTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/ChangeShuffleStateTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 import testing.faker.PlayerStateFaker;
 
-import static com.odeyalo.sonata.connect.entity.PlayerStateEntity.SHUFFLE_ENABLED;
 import static com.odeyalo.sonata.connect.model.ShuffleMode.ENABLED;
 import static com.odeyalo.sonata.connect.model.ShuffleMode.OFF;
 import static testing.factory.DefaultPlayerOperationsTestableBuilder.testableBuilder;

--- a/src/test/java/com/odeyalo/sonata/connect/service/player/CurrentPlayerStateTest.java
+++ b/src/test/java/com/odeyalo/sonata/connect/service/player/CurrentPlayerStateTest.java
@@ -4,7 +4,6 @@ import com.odeyalo.sonata.connect.entity.PlayerStateEntity;
 import com.odeyalo.sonata.connect.model.CurrentPlayerState;
 import com.odeyalo.sonata.connect.model.PlayableItem;
 import com.odeyalo.sonata.connect.model.User;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import reactor.test.StepVerifier;
 
@@ -79,22 +78,6 @@ class CurrentPlayerStateTest extends DefaultPlayerOperationsTest {
                 .map(CurrentPlayerState::getShuffleState)
                 .as(StepVerifier::create)
                 .expectNext(state.getShuffleState())
-                .verifyComplete();
-    }
-
-    @Test
-    @Disabled("Disabled for a while. Fragile test")
-    void shouldReturnProgressMs() {
-        PlayerStateEntity state = existingPlayerState();
-
-        DefaultPlayerOperations testable = testableBuilder()
-                .withState(state)
-                .build();
-
-        testable.currentState(EXISTING_USER)
-                .map(CurrentPlayerState::getProgressMs)
-                .as(StepVerifier::create)
-                .expectNext(state.getProgressMs())
                 .verifyComplete();
     }
 

--- a/src/test/java/testing/faker/PlayableItemFaker.java
+++ b/src/test/java/testing/faker/PlayableItemFaker.java
@@ -2,15 +2,15 @@ package testing.faker;
 
 import com.github.javafaker.Faker;
 import com.odeyalo.sonata.common.context.ContextUri;
-import com.odeyalo.sonata.connect.model.PlayableItem;
-import com.odeyalo.sonata.connect.model.TrackItem;
-import com.odeyalo.sonata.connect.model.TrackItemSpec;
+import com.odeyalo.sonata.connect.model.*;
 import lombok.AccessLevel;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.experimental.FieldDefaults;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
 
 import static com.odeyalo.sonata.connect.model.PlayableItemDuration.ofMilliseconds;
 
@@ -19,6 +19,7 @@ import static com.odeyalo.sonata.connect.model.PlayableItemDuration.ofMillisecon
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class PlayableItemFaker {
     protected String id;
+    protected PlayableItemDuration duration;
 
     public PlayableItemFaker() {
         this.id = RandomStringUtils.randomAlphanumeric(16);
@@ -29,7 +30,18 @@ public class PlayableItemFaker {
     }
 
     public PlayableItem get() {
-        return TrackItemFaker.create().get();
+        final TrackItemFaker builder = TrackItemFaker.create();
+
+        if (duration != null) {
+            builder.withDuration(duration);
+        }
+
+        return builder.get();
+    }
+
+    public PlayableItemFaker setDuration(final Duration itemDuration) {
+        this.duration = PlayableItemDuration.fromJavaDuration(itemDuration);
+        return this;
     }
 
     public static class TrackItemFaker extends PlayableItemFaker {
@@ -40,7 +52,6 @@ public class PlayableItemFaker {
             super();
             builder
                     .name(faker.internet().domainWord())
-                    .duration(ofMilliseconds(faker.random().nextLong(256_000L)))
                     .contextUri(ContextUri.forTrack(id))
                     .explicit(faker.random().nextBoolean())
                     .order(TrackItemSpec.Order.of(
@@ -72,9 +83,17 @@ public class PlayableItemFaker {
             return this;
         }
 
+        public PlayableItemFaker withDuration(final PlayableItemDuration duration) {
+            this.duration = duration;
+            builder.duration(duration);
+            return this;
+        }
+
         @Override
         public TrackItem get() {
-            return builder.id(id)
+            return builder
+                    .id(id)
+                    .duration(duration == null ? ofMilliseconds(faker.random().nextLong(256_000L)) : duration)
                     .build();
         }
     }

--- a/src/test/java/testing/time/TestingClock.java
+++ b/src/test/java/testing/time/TestingClock.java
@@ -1,0 +1,44 @@
+package testing.time;
+
+import com.odeyalo.sonata.connect.support.time.Clock;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Instant;
+
+/**
+ * An implementation of {@link Clock} that exposes methods to control the time in tests
+ */
+public final class TestingClock implements Clock {
+    private Instant value;
+
+    public TestingClock(@NotNull final Instant initialValue) {
+        this.value = initialValue;
+    }
+
+    @Override
+    @NotNull
+    public Instant now() {
+        return value;
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        return value.toEpochMilli();
+    }
+
+    /**
+     * Simulate waiting for specified number of seconds
+     * @param seconds - seconds to wait
+     */
+    public void waitSeconds(final int seconds) {
+        this.value = value.plusSeconds(seconds);
+    }
+
+    /**
+     * Same as {@link #waitSeconds(int)} but uses milliseconds
+     * @param millis - millis to wait
+     */
+    public void waitMillis(final long millis) {
+        this.value = value.plusMillis(millis);
+    }
+}


### PR DESCRIPTION
Fixed bug when progress was calculated wrongly because playStartTime, lastPauseTime weren't persisted to repository.
Added NOT FRAGILE unit tests for playback progress calculation by introducing Clock object.
